### PR TITLE
FIX issue 35: DefaultRobotsTxtProvider fails parsing robots.txt

### DIFF
--- a/norconex-collector-http/src/main/java/com/norconex/collector/http/robot/impl/DefaultRobotsTxtProvider.java
+++ b/norconex-collector-http/src/main/java/com/norconex/collector/http/robot/impl/DefaultRobotsTxtProvider.java
@@ -99,6 +99,10 @@ public class DefaultRobotsTxtProvider implements IRobotsTxtProvider {
         boolean parse = false;
         String line;
         while ((line = br.readLine()) != null) {
+            
+            if (ignoreLine(line))continue;
+            line = cleanLineFromComments(line);
+            
             String key = line.replaceFirst("(.*?)(:.*)", "$1").trim();
             String value = line.replaceFirst("(.*?:)(.*)", "$2").trim();
             
@@ -123,13 +127,27 @@ public class DefaultRobotsTxtProvider implements IRobotsTxtProvider {
                 if ("crawl-delay".equalsIgnoreCase(key)) {
                     data.crawlDelay = value;
                 } else {
-                    data.rules.put(key, value);
+                    data.rules.put(value, key);
                 }
             }
         }
         isr.close();
         
         return data.toRobotsTxt(baseURL);
+    }
+
+    private String cleanLineFromComments(String line) {
+        if (line.matches(".*\\s+#.*")){
+            line = line.replaceFirst("\\s+#.*", "");
+        }
+        return line;
+    }
+
+    private boolean ignoreLine(String line) {
+        if (line.matches("\\s*#.*") || line.equals("Allow: /")) {
+            return true;
+        }
+        return false;
     }
     
     private RobotData.Precision matchesUserAgent(
@@ -175,14 +193,18 @@ public class DefaultRobotsTxtProvider implements IRobotsTxtProvider {
         }
         private RobotsTxt toRobotsTxt(String baseURL) {
             List<IURLFilter> filters = new ArrayList<IURLFilter>();
-            for (String key : rules.keySet()) {
-                String value = rules.get(key);
-                if ("disallow".equalsIgnoreCase(key)) {
-                    filters.add(buildURLFilter(
-                            baseURL, value, OnMatch.EXCLUDE));
-                } else if ("allow".equalsIgnoreCase(key)) {
-                    filters.add(buildURLFilter(
-                            baseURL, value, OnMatch.INCLUDE));
+            for (String path : rules.keySet()) {
+                String rule = rules.get(path);
+                if ("disallow".equalsIgnoreCase(rule)) {
+                    IURLFilter filter;
+                    filter = buildURLFilter(baseURL, path, OnMatch.EXCLUDE);
+                    LOG.debug("Add filter from robots.txt: " + filter.toString());
+                    filters.add(filter);
+                } else if ("allow".equalsIgnoreCase(rule)) {                    
+                    IURLFilter filter;
+                    filter = buildURLFilter(baseURL, path, OnMatch.INCLUDE);
+                    LOG.debug("Add filter from robots.txt: " + filter.toString());
+                    filters.add(filter);
                 } 
             }
             float delay = NumberUtils.toFloat(
@@ -197,7 +219,7 @@ public class DefaultRobotsTxtProvider implements IRobotsTxtProvider {
             String regex = path;
             regex = regex.replaceAll("\\*", ".*");
             if (!regex.endsWith("$")) {
-                regex += ".*";
+                regex += "?.*";
             }
             regex = baseURL + regex;
             RegexURLFilter filter = new RegexURLFilter(regex, onMatch, false) {
@@ -205,7 +227,7 @@ public class DefaultRobotsTxtProvider implements IRobotsTxtProvider {
                         -5051322223143577684L;
                 @Override
                 public String toString() {
-                    return "Robots.txt (" 
+                    return "Robots.txt ("
                             + (onMatch == OnMatch.INCLUDE 
                             ? "Allow:" : "Disallow:") + path + ")";
                 }

--- a/norconex-collector-http/src/test/java/com/norconex/collector/http/robot/impl/DefaultRobotsTxtProviderTest.java
+++ b/norconex-collector-http/src/test/java/com/norconex/collector/http/robot/impl/DefaultRobotsTxtProviderTest.java
@@ -18,6 +18,7 @@
  */
 package com.norconex.collector.http.robot.impl;
 
+import com.norconex.collector.http.filter.IURLFilter;
 import java.io.IOException;
 
 import org.apache.commons.io.IOUtils;
@@ -55,24 +56,45 @@ public class DefaultRobotsTxtProviderTest {
               + "Disallow: /dontgo/there/\n"
               + "User-agent: mister-crawler\n"
               + "Disallow: /bathroom/\n";
+        String robotTxt5 = 
+                "# robots.txt\n"
+              + "User-agent: *\n"
+              + "Disallow: /some/fake/ # Spiders, keep out! \n"
+              + "Disallow: /spidertrap/\n"
+              + "Allow: /open/\n"
+              + "Allow: /\n";
         
         
-        Assert.assertEquals("Robots.txt (Disallow:/bathroom/)", 
-                parseRobotRule("mister-crawler", robotTxt1));
-        Assert.assertEquals("Robots.txt (Disallow:/bathroom/)", 
-                parseRobotRule("mister-crawler", robotTxt2));
-        Assert.assertEquals("Robots.txt (Disallow:/dontgo/there/)", 
-                parseRobotRule("mister-crawler", robotTxt3));
-        Assert.assertEquals("Robots.txt (Disallow:/bathroom/)", 
-                parseRobotRule("mister-crawler", robotTxt4));
+        Assert.assertEquals("Robots.txt (Disallow:/bathroom/)",
+                parseRobotRule("mister-crawler", robotTxt1)[1].toString());
+        Assert.assertEquals("Robots.txt (Disallow:/bathroom/)",
+                parseRobotRule("mister-crawler", robotTxt2)[0].toString());
+        Assert.assertEquals("Robots.txt (Disallow:/dontgo/there/)",
+                parseRobotRule("mister-crawler", robotTxt3)[0].toString());
+        Assert.assertEquals("Robots.txt (Disallow:/bathroom/)",
+                parseRobotRule("mister-crawler", robotTxt4)[1].toString());
+        
+        Assert.assertEquals("Robots.txt (Disallow:/some/fake/)",
+                parseRobotRule("mister-crawler", robotTxt5)[0].toString());
+        Assert.assertEquals("Robots.txt (Disallow:/spidertrap/)",
+                parseRobotRule("mister-crawler", robotTxt5)[1].toString());
+        Assert.assertEquals("Robots.txt (Allow:/open/)", 
+                parseRobotRule("mister-crawler", robotTxt5)[2].toString());
+        
     }
     
-    private String parseRobotRule(String agent, String content) 
+    private IURLFilter[] parseRobotRule(String agent, String content, String url) 
             throws IOException {
         DefaultRobotsTxtProvider robotProvider = new DefaultRobotsTxtProvider();
         return robotProvider.parseRobotsTxt(
                 IOUtils.toInputStream(content), 
-                "http://www.testinguseragents.test/some/fake/url.html",
-                "mister-crawler").getFilters()[0].toString();
+                url,
+                "mister-crawler").getFilters();
+    }
+    
+    private IURLFilter[] parseRobotRule(String agent, String content) 
+            throws IOException {
+        return parseRobotRule(agent, content, 
+                "http://www.testinguseragents.test/some/fake/url.html");
     }
 }


### PR DESCRIPTION
- Add handling for commented lines.
- Add handling for partly commented lines.
- Skip rules which allows everything (Allow: /).
- Read all rules which should result in a filter.

The regex question mark on line 222 in DefaultRobotsTxtProvider.java was needed in order to restrict the crawler from crawling the restricted path (The path /spidertrap/ should not be crawled when Disallow: /spidertrap/ is given as a rule).
