### PR TITLE
Update incorrect output directory in minimum-config.xml

### DIFF
--- a/src/site/resources/examples/minimum/minimum-config.xml
+++ b/src/site/resources/examples/minimum/minimum-config.xml
@@ -21,7 +21,7 @@
 <httpcollector id="Minimum Config HTTP Collector">
 
   <!-- Decide where to store generated files. -->
-  <workDir>./examples-output/complex</workDir>
+  <workDir>./examples-output/simple</workDir>
 
   <crawlers>
     <crawler id="Norconex Minimum Test Page">
@@ -64,5 +64,6 @@
 
     </crawler>
   </crawlers>
+
 
 </httpcollector>


### PR DESCRIPTION
This mistake can confuse new users who are following the intro docs which suggest running the examples.