### PR TITLE
Refactor test assertions and improve readability in AzureBlobModelTest and HdfsModelTest; enhance SmbModelTest configuration logic

### DIFF
--- a/crawler/fs/src/test/java/com/norconex/crawler/fs/fetch/impl/azureblob/AzureBlobModelTest.java
+++ b/crawler/fs/src/test/java/com/norconex/crawler/fs/fetch/impl/azureblob/AzureBlobModelTest.java
@@ -245,7 +245,8 @@ class AzureBlobModelTest {
         try (var channel = provider.newByteChannel(path, Set.of())) {
             var dst = ByteBuffer.allocate(8);
             assertThat(channel.read(dst)).isEqualTo(3);
-            assertThat(channel.read(ByteBuffer.allocate(1))).isEqualTo(-1);
+            assertThat(channel.read(ByteBuffer.allocate(1)))
+                    .isEqualTo(-1);
             assertThat(channel.position()).isEqualTo(3L);
             channel.position(1);
             assertThat(channel.position()).isEqualTo(1L);
@@ -344,7 +345,8 @@ class AzureBlobModelTest {
         assertThatThrownBy(() -> provider.newDirectoryStream(
                 fs.getPath("/"), p -> true))
                         .isInstanceOf(java.io.IOException.class)
-                        .hasMessageContaining("Could not list Azure blobs");
+                        .hasMessageContaining(
+                                "Could not list Azure blobs");
     }
 
     @Test
@@ -375,13 +377,15 @@ class AzureBlobModelTest {
         when(nullLenProps.getLastModified()).thenReturn(null);
 
         when(listing.iterator()).thenReturn(
-                List.of(blankPrefix, selfFile, nullPropFile, nullLenFile)
+                List.of(blankPrefix, selfFile, nullPropFile,
+                        nullLenFile)
                         .iterator());
         when(containerClient.listBlobsByHierarchy(eq("/"),
                 any(ListBlobsOptions.class), isNull()))
                         .thenReturn(listing);
 
-        try (var stream = provider.newDirectoryStream(dirPath, p -> false)) {
+        try (var stream = provider.newDirectoryStream(dirPath,
+                p -> false)) {
             assertThat(stream.iterator().hasNext()).isFalse();
         }
 
@@ -389,7 +393,8 @@ class AzureBlobModelTest {
                 BasicFileAttributes.class).size()).isZero();
         assertThat(provider.readAttributes(fs.getPath("/dir/b.txt"),
                 BasicFileAttributes.class).lastModifiedTime())
-                        .isEqualTo(FileTime.fromMillis(0));
+                        .isEqualTo(FileTime
+                                .fromMillis(0));
 
         assertThatThrownBy(() -> provider.readAttributes(
                 fs.getPath("/x.txt"),
@@ -403,7 +408,8 @@ class AzureBlobModelTest {
                 .thenReturn(err500Blob);
         when(err500Blob.getProperties()).thenThrow(err500);
         assertThatThrownBy(() -> provider.readAttributes(
-                fs.getPath("/err500.txt"), BasicFileAttributes.class))
+                fs.getPath("/err500.txt"),
+                BasicFileAttributes.class))
                         .isInstanceOf(java.io.IOException.class)
                         .hasMessageContaining(
                                 "Could not read Azure blob attributes");
@@ -419,7 +425,8 @@ class AzureBlobModelTest {
                 any(ListBlobsOptions.class), isNull()))
                         .thenReturn(vdirPaged);
         assertThat(provider.readAttributes(
-                fs.getPath("/vdir/ghost.txt"), BasicFileAttributes.class)
+                fs.getPath("/vdir/ghost.txt"),
+                BasicFileAttributes.class)
                 .isDirectory()).isTrue();
 
         var missingBlob = mock(BlobClient.class);
@@ -431,7 +438,8 @@ class AzureBlobModelTest {
                 any(ListBlobsOptions.class), isNull()))
                         .thenReturn(missingPaged);
         assertThatThrownBy(() -> provider.readAttributes(
-                fs.getPath("/missing/ghost.txt"), BasicFileAttributes.class))
+                fs.getPath("/missing/ghost.txt"),
+                BasicFileAttributes.class))
                         .isInstanceOf(NoSuchFileException.class);
 
         var failListBlob = mock(BlobClient.class);
@@ -444,7 +452,8 @@ class AzureBlobModelTest {
                 any(ListBlobsOptions.class), isNull()))
                         .thenThrow(listErr);
         assertThatThrownBy(() -> provider.readAttributes(
-                fs.getPath("/broken/ghost.txt"), BasicFileAttributes.class))
+                fs.getPath("/broken/ghost.txt"),
+                BasicFileAttributes.class))
                         .isInstanceOf(java.io.IOException.class)
                         .hasMessageContaining(
                                 "Could not check Azure virtual directory");
@@ -454,16 +463,19 @@ class AzureBlobModelTest {
                 .thenReturn(ioBlobClient);
         when(ioBlobClient.openInputStream()).thenThrow(err500);
         assertThatThrownBy(
-                () -> provider.newInputStream(fs.getPath("/iofail.txt")))
-                        .isInstanceOf(java.io.IOException.class)
-                        .hasMessageContaining("Could not read Azure blob");
+                () -> provider.newInputStream(
+                        fs.getPath("/iofail.txt")))
+                                .isInstanceOf(java.io.IOException.class)
+                                .hasMessageContaining(
+                                        "Could not read Azure blob");
     }
 
     @SafeVarargs
     private static PagedIterable<BlobItem> mockPagedOf(BlobItem... items) {
         @SuppressWarnings("unchecked")
         var paged = mock(PagedIterable.class);
-        when(paged.iterator()).thenReturn(Arrays.asList(items).iterator());
+        when(paged.iterator())
+                .thenReturn(Arrays.asList(items).iterator());
         return paged;
     }
 }

--- a/crawler/fs/src/test/java/com/norconex/crawler/fs/fetch/impl/hdfs/HdfsModelTest.java
+++ b/crawler/fs/src/test/java/com/norconex/crawler/fs/fetch/impl/hdfs/HdfsModelTest.java
@@ -21,6 +21,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.NonWritableChannelException;
@@ -387,5 +390,73 @@ class HdfsModelTest {
                 fs.getPath("/root"), p -> false)) {
             assertThat(stream.iterator().hasNext()).isFalse();
         }
+
+        try (var stream = provider.newDirectoryStream(
+                fs.getPath("/root"), null)) {
+            assertThat(stream.iterator().hasNext()).isTrue();
+        }
+    }
+
+    @Test
+    void testProviderPrivateHelperErrorBranches() throws Exception {
+        var provider = new HdfsFileSystemProvider();
+        var client = mock(CloseableHttpClient.class);
+
+        var fsNoKerberos = provider.getOrCreateFileSystem(
+                URI.create("webhdfs://host1.example.com:9870/"),
+                "alice", null, host -> client);
+        var fsKerberos = provider.getOrCreateFileSystem(
+                URI.create("webhdfs://host2.example.com:9870/"),
+                "alice", new Subject(), host -> client);
+
+        var providerClass = HdfsFileSystemProvider.class;
+        Method doAs = providerClass.getDeclaredMethod(
+                "doAs", HdfsFileSystem.class,
+                java.util.concurrent.Callable.class);
+        doAs.setAccessible(true);
+
+        // Covers doAs branch: non-Kerberos callable throws checked Exception.
+        var noKerberosEx = assertThrowsFromReflectiveCall(
+                () -> doAs.invoke(provider, fsNoKerberos,
+                        (java.util.concurrent.Callable<Object>) () -> {
+                            throw new Exception("checked");
+                        }));
+        assertThat(noKerberosEx).isInstanceOf(IOException.class);
+
+        // Covers doAs CompletionException branch with IOException cause.
+        var kerberosIoEx = assertThrowsFromReflectiveCall(
+                () -> doAs.invoke(provider, fsKerberos,
+                        (java.util.concurrent.Callable<Object>) () -> {
+                            throw new IOException("io cause");
+                        }));
+        assertThat(kerberosIoEx).isInstanceOf(IOException.class)
+                .hasMessageContaining("io cause");
+
+        // Covers doAs CompletionException branch with non-IO cause.
+        var kerberosOtherEx = assertThrowsFromReflectiveCall(
+                () -> doAs.invoke(provider, fsKerberos,
+                        (java.util.concurrent.Callable<Object>) () -> {
+                            throw new java.util.concurrent.CompletionException(
+                                    new IllegalStateException("boom"));
+                        }));
+        assertThat(kerberosOtherEx).isInstanceOf(IOException.class)
+                .hasMessageContaining("Kerberos-authenticated request failed");
+    }
+
+    private static Throwable assertThrowsFromReflectiveCall(
+            ReflectiveCall reflectiveCall) {
+        try {
+            reflectiveCall.run();
+        } catch (InvocationTargetException e) {
+            return e.getCause();
+        } catch (Exception e) {
+            return e;
+        }
+        throw new AssertionError("Expected reflective call to fail");
+    }
+
+    @FunctionalInterface
+    private interface ReflectiveCall {
+        void run() throws Exception;
     }
 }

--- a/crawler/fs/src/test/java/com/norconex/crawler/fs/fetch/impl/smb/SmbModelTest.java
+++ b/crawler/fs/src/test/java/com/norconex/crawler/fs/fetch/impl/smb/SmbModelTest.java
@@ -432,10 +432,10 @@ class SmbModelTest {
 
     static void configureSmbFileMock(SmbFile mocked, int count, ACE ace)
             throws java.io.IOException {
-                // Mockito construction index may be 0- or 1-based depending on version.
-                var idx = count <= 0 ? 0 : count - 1;
-                if (idx == 0) {
-                        when(mocked.exists()).thenReturn(true);
+        // Mockito construction index may be 0- or 1-based depending on version.
+        var idx = count <= 0 ? 0 : count - 1;
+        if (idx == 0) {
+            when(mocked.exists()).thenReturn(true);
 
             var childFile = mock(SmbFile.class);
             when(childFile.getName()).thenReturn("a.txt");
@@ -454,16 +454,16 @@ class SmbModelTest {
             });
             return;
         }
-                if (idx == 1) {
+        if (idx == 1) {
             when(mocked.isDirectory()).thenReturn(true);
             return;
         }
-                if (idx == 2) {
+        if (idx == 2) {
             when(mocked.getSecurity()).thenReturn(new ACE[] {
                     ace
             });
             return;
         }
-                // Extra constructions are irrelevant for this scenario.
+        // Extra constructions are irrelevant for this scenario.
     }
 }


### PR DESCRIPTION
Signed-off-by: Pascal Essiembre <pascal.essiembre@norconex.com>

## Description

<!-- Describe the changes in this pull request. -->

## Motivation & Context

<!-- Why is this change needed? What problem does it solve? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Internal/maintenance (CI, formatting, refactoring with no user impact)

## Contributor Agreement

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the DCO
- [ ] All commits in this PR are signed off (`-s`) and GPG-signed (`-S`)

## Testing

<!-- How has this been tested? -->

## Release Notes

**If this PR will be included in an upcoming release, describe the user-facing change here (1-2 lines):**

<!-- Example:
"Fixed URL encoding in query parameters (fixes #123)"
or
"Added support for parallel processing with new maxThreads configuration"
-->

---

**Note:** When a release is prepared, the changelog file will be built from merged PRs and the release notes provided above.
