### PR TITLE
Refactor path implementations to extend ReadOnlyPath

### DIFF
--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/ReadOnlyPath.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/ReadOnlyPath.java
@@ -1,0 +1,261 @@
+/* Copyright 2026 Norconex Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.norconex.crawler.fs.fetch.impl;
+
+import java.io.File;
+import java.nio.file.FileSystem;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent.Kind;
+import java.nio.file.WatchEvent.Modifier;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Shared absolute-path behavior for remote, read-only file systems.
+ */
+public abstract class ReadOnlyPath implements Path {
+
+    private final FileSystem fileSystem;
+    private final List<String> segments;
+    private final String displayName;
+
+    protected ReadOnlyPath(
+            FileSystem fileSystem, List<String> segments, String displayName) {
+        this.fileSystem = fileSystem;
+        this.segments = segments;
+        this.displayName = displayName;
+    }
+
+    protected static List<String> parse(String path) {
+        List<String> result = new ArrayList<>();
+        for (String segment : path.split("/")) {
+            if (segment.isEmpty() || ".".equals(segment)) {
+                continue;
+            }
+            if ("..".equals(segment)) {
+                if (!result.isEmpty()) {
+                    result.remove(result.size() - 1);
+                }
+            } else {
+                result.add(segment);
+            }
+        }
+        return result;
+    }
+
+    protected final FileSystem rawFileSystem() {
+        return fileSystem;
+    }
+
+    protected final List<String> segments() {
+        return segments;
+    }
+
+    protected final String normalizedPath() {
+        return "/" + String.join("/", segments);
+    }
+
+    protected abstract Path createPath(List<String> segments);
+
+    @Override
+    public FileSystem getFileSystem() {
+        return fileSystem;
+    }
+
+    @Override
+    public boolean isAbsolute() {
+        return true;
+    }
+
+    @Override
+    public Path getRoot() {
+        return createPath(List.of());
+    }
+
+    @Override
+    public Path getFileName() {
+        if (segments.isEmpty()) {
+            return null;
+        }
+        return createPath(List.of(segments.get(segments.size() - 1)));
+    }
+
+    @Override
+    public Path getParent() {
+        if (segments.isEmpty()) {
+            return null;
+        }
+        return createPath(segments.subList(0, segments.size() - 1));
+    }
+
+    @Override
+    public int getNameCount() {
+        return segments.size();
+    }
+
+    @Override
+    public Path getName(int index) {
+        return createPath(List.of(segments.get(index)));
+    }
+
+    @Override
+    public Path subpath(int beginIndex, int endIndex) {
+        return createPath(
+                new ArrayList<>(segments.subList(beginIndex, endIndex)));
+    }
+
+    @Override
+    public boolean startsWith(Path other) {
+        return other instanceof ReadOnlyPath o
+                && o.rawFileSystem() == rawFileSystem()
+                && segments.size() >= o.segments.size()
+                && segments.subList(0, o.segments.size()).equals(o.segments);
+    }
+
+    @Override
+    public boolean startsWith(String other) {
+        return startsWith(fileSystem.getPath(other));
+    }
+
+    @Override
+    public boolean endsWith(Path other) {
+        return other instanceof ReadOnlyPath o
+                && o.rawFileSystem() == rawFileSystem()
+                && segments.size() >= o.segments.size()
+                && segments.subList(
+                        segments.size() - o.segments.size(),
+                        segments.size()).equals(o.segments);
+    }
+
+    @Override
+    public boolean endsWith(String other) {
+        return endsWith(fileSystem.getPath(other));
+    }
+
+    @Override
+    public Path normalize() {
+        return this;
+    }
+
+    @Override
+    public Path resolve(Path other) {
+        if (!(other instanceof ReadOnlyPath o)) {
+            throw new IllegalArgumentException(
+                    "Not a " + displayName + ": " + other);
+        }
+        if (o.isAbsolute()) {
+            return o;
+        }
+        var combined = new ArrayList<>(segments);
+        combined.addAll(o.segments);
+        return createPath(combined);
+    }
+
+    @Override
+    public Path resolve(String other) {
+        return resolve(fileSystem.getPath(other));
+    }
+
+    @Override
+    public Path resolveSibling(Path other) {
+        var parent = getParent();
+        return parent == null ? other : parent.resolve(other);
+    }
+
+    @Override
+    public Path resolveSibling(String other) {
+        return resolveSibling(fileSystem.getPath(other));
+    }
+
+    @Override
+    public Path relativize(Path other) {
+        if (!(other instanceof ReadOnlyPath o)
+                || o.rawFileSystem() != rawFileSystem()) {
+            throw new IllegalArgumentException(
+                    "Not a " + displayName + ": " + other);
+        }
+        var common = 0;
+        while (common < segments.size() && common < o.segments.size()
+                && segments.get(common).equals(o.segments.get(common))) {
+            common++;
+        }
+        var result = new ArrayList<String>();
+        for (var i = common; i < segments.size(); i++) {
+            result.add("..");
+        }
+        result.addAll(o.segments.subList(common, o.segments.size()));
+        return createPath(result);
+    }
+
+    @Override
+    public Path toAbsolutePath() {
+        return this;
+    }
+
+    @Override
+    public Path toRealPath(LinkOption... options) {
+        return this;
+    }
+
+    @Override
+    public File toFile() {
+        throw new UnsupportedOperationException(
+                displayName + " paths have no local file representation.");
+    }
+
+    @Override
+    public WatchKey register(
+            WatchService watcher, Kind<?>[] events, Modifier... modifiers) {
+        throw new UnsupportedOperationException(
+                displayName + " paths do not support watching.");
+    }
+
+    @Override
+    public Iterator<Path> iterator() {
+        List<Path> names = new ArrayList<>();
+        for (var i = 0; i < segments.size(); i++) {
+            names.add(getName(i));
+        }
+        return names.iterator();
+    }
+
+    @Override
+    public int compareTo(Path other) {
+        return normalizedPath()
+                .compareTo(((ReadOnlyPath) other).normalizedPath());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rawFileSystem(), segments);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof ReadOnlyPath o
+                && rawFileSystem() == o.rawFileSystem()
+                && segments.equals(o.segments);
+    }
+
+    @Override
+    public String toString() {
+        return normalizedPath();
+    }
+}

--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/adlsgen2/AdlsGen2Path.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/adlsgen2/AdlsGen2Path.java
@@ -14,62 +14,37 @@
  */
 package com.norconex.crawler.fs.fetch.impl.adlsgen2;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.nio.file.WatchEvent.Kind;
-import java.nio.file.WatchEvent.Modifier;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
+
+import com.norconex.crawler.fs.fetch.impl.ReadOnlyPath;
 
 /**
  * A path within an ADLS Gen2 file system.
  */
-final class AdlsGen2Path implements Path {
+final class AdlsGen2Path extends ReadOnlyPath {
 
     private final AdlsGen2FileSystem fs;
-    private final List<String> segments;
 
     AdlsGen2Path(AdlsGen2FileSystem fs, String path) {
-        this(fs, parse(path));
+        this(fs, ReadOnlyPath.parse(path));
     }
 
     private AdlsGen2Path(AdlsGen2FileSystem fs, List<String> segments) {
+        super(fs, List.copyOf(segments), "AdlsGen2Path");
         this.fs = fs;
-        this.segments = segments;
-    }
-
-    private static List<String> parse(String path) {
-        List<String> result = new ArrayList<>();
-        for (String segment : path.split("/")) {
-            if (segment.isEmpty() || ".".equals(segment)) {
-                continue;
-            }
-            if ("..".equals(segment)) {
-                if (!result.isEmpty()) {
-                    result.remove(result.size() - 1);
-                }
-            } else {
-                result.add(segment);
-            }
-        }
-        return result;
     }
 
     String path() {
-        return "/" + String.join("/", segments);
+        return normalizedPath();
     }
 
     String pathName() {
-        return String.join("/", segments);
+        return String.join("/", segments());
     }
 
     @Override
@@ -78,124 +53,8 @@ final class AdlsGen2Path implements Path {
     }
 
     @Override
-    public boolean isAbsolute() {
-        return true;
-    }
-
-    @Override
-    public Path getRoot() {
-        return new AdlsGen2Path(fs, List.of());
-    }
-
-    @Override
-    public Path getFileName() {
-        if (segments.isEmpty()) {
-            return null;
-        }
-        return new AdlsGen2Path(fs, List.of(segments.get(segments.size() - 1)));
-    }
-
-    @Override
-    public Path getParent() {
-        if (segments.isEmpty()) {
-            return null;
-        }
-        return new AdlsGen2Path(fs, segments.subList(0, segments.size() - 1));
-    }
-
-    @Override
-    public int getNameCount() {
-        return segments.size();
-    }
-
-    @Override
-    public Path getName(int index) {
-        return new AdlsGen2Path(fs, List.of(segments.get(index)));
-    }
-
-    @Override
-    public Path subpath(int beginIndex, int endIndex) {
-        return new AdlsGen2Path(fs,
-                new ArrayList<>(segments.subList(beginIndex, endIndex)));
-    }
-
-    @Override
-    public boolean startsWith(Path other) {
-        return other instanceof AdlsGen2Path o && o.fs == fs
-                && segments.size() >= o.segments.size()
-                && segments.subList(0, o.segments.size()).equals(o.segments);
-    }
-
-    @Override
-    public boolean startsWith(String other) {
-        return startsWith(fs.getPath(other));
-    }
-
-    @Override
-    public boolean endsWith(Path other) {
-        return other instanceof AdlsGen2Path o && o.fs == fs
-                && segments.size() >= o.segments.size()
-                && segments.subList(segments.size() - o.segments.size(),
-                        segments.size()).equals(o.segments);
-    }
-
-    @Override
-    public boolean endsWith(String other) {
-        return endsWith(fs.getPath(other));
-    }
-
-    @Override
-    public Path normalize() {
-        return this;
-    }
-
-    @Override
-    public Path resolve(Path other) {
-        if (!(other instanceof AdlsGen2Path o)) {
-            throw new IllegalArgumentException(
-                    "Not an AdlsGen2Path: " + other);
-        }
-        if (o.isAbsolute()) {
-            return o;
-        }
-        var combined = new ArrayList<>(segments);
-        combined.addAll(o.segments);
-        return new AdlsGen2Path(fs, combined);
-    }
-
-    @Override
-    public Path resolve(String other) {
-        return resolve(fs.getPath(other));
-    }
-
-    @Override
-    public Path resolveSibling(Path other) {
-        var parent = getParent();
-        return parent == null ? other : parent.resolve(other);
-    }
-
-    @Override
-    public Path resolveSibling(String other) {
-        return resolveSibling(fs.getPath(other));
-    }
-
-    @Override
-    public Path relativize(Path other) {
-        if (!(other instanceof AdlsGen2Path o) || o.fs != fs) {
-            throw new IllegalArgumentException(
-                    "Not an AdlsGen2Path: " + other);
-        }
-        var common = 0;
-        while (common < segments.size() && common < o.segments.size()
-                && segments.get(common).equals(o.segments.get(common))) {
-            common++;
-        }
-        var result = new ArrayList<String>();
-        for (var i = common; i < segments.size(); i++) {
-            result.add("..");
-        }
-        result.addAll(o.segments.subList(common, o.segments.size()));
-        return new AdlsGen2Path(fs, result);
+    protected Path createPath(List<String> segments) {
+        return new AdlsGen2Path(fs, segments);
     }
 
     @Override
@@ -212,63 +71,5 @@ final class AdlsGen2Path implements Path {
         } catch (URISyntaxException e) {
             throw new UncheckedIOException(new IOException(e));
         }
-    }
-
-    @Override
-    public Path toAbsolutePath() {
-        return this;
-    }
-
-    @Override
-    public Path toRealPath(LinkOption... options) {
-        return this;
-    }
-
-    @Override
-    public File toFile() {
-        throw new UnsupportedOperationException(
-                "ADLS Gen2 paths have no local file representation.");
-    }
-
-    @Override
-    public WatchKey register(
-            WatchService watcher, Kind<?>[] events, Modifier... modifiers) {
-        throw new UnsupportedOperationException(
-                "ADLS Gen2 paths do not support watching.");
-    }
-
-    @Override
-    public Iterator<Path> iterator() {
-        List<Path> names = new ArrayList<>();
-        for (var i = 0; i < segments.size(); i++) {
-            names.add(getName(i));
-        }
-        return names.iterator();
-    }
-
-    @Override
-    public int compareTo(Path other) {
-        return path().compareTo(((AdlsGen2Path) other).path());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(fs, segments);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof AdlsGen2Path other)) {
-            return false;
-        }
-        return fs == other.fs && segments.equals(other.segments);
-    }
-
-    @Override
-    public String toString() {
-        return path();
     }
 }

--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/azureblob/AzureBlobPath.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/azureblob/AzureBlobPath.java
@@ -14,62 +14,37 @@
  */
 package com.norconex.crawler.fs.fetch.impl.azureblob;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.nio.file.WatchEvent.Kind;
-import java.nio.file.WatchEvent.Modifier;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
+
+import com.norconex.crawler.fs.fetch.impl.ReadOnlyPath;
 
 /**
  * A path within an {@link AzureBlobFileSystem}.
  */
-final class AzureBlobPath implements Path {
+final class AzureBlobPath extends ReadOnlyPath {
 
     private final AzureBlobFileSystem fs;
-    private final List<String> segments;
 
     AzureBlobPath(AzureBlobFileSystem fs, String path) {
-        this(fs, parse(path));
+        this(fs, ReadOnlyPath.parse(path));
     }
 
     private AzureBlobPath(AzureBlobFileSystem fs, List<String> segments) {
+        super(fs, List.copyOf(segments), "AzureBlobPath");
         this.fs = fs;
-        this.segments = segments;
-    }
-
-    private static List<String> parse(String path) {
-        List<String> result = new ArrayList<>();
-        for (String segment : path.split("/")) {
-            if (segment.isEmpty() || ".".equals(segment)) {
-                continue;
-            }
-            if ("..".equals(segment)) {
-                if (!result.isEmpty()) {
-                    result.remove(result.size() - 1);
-                }
-            } else {
-                result.add(segment);
-            }
-        }
-        return result;
     }
 
     String path() {
-        return "/" + String.join("/", segments);
+        return normalizedPath();
     }
 
     String blobName() {
-        return String.join("/", segments);
+        return String.join("/", segments());
     }
 
     String blobPrefix() {
@@ -83,126 +58,8 @@ final class AzureBlobPath implements Path {
     }
 
     @Override
-    public boolean isAbsolute() {
-        return true;
-    }
-
-    @Override
-    public Path getRoot() {
-        return new AzureBlobPath(fs, List.of());
-    }
-
-    @Override
-    public Path getFileName() {
-        if (segments.isEmpty()) {
-            return null;
-        }
-        return new AzureBlobPath(fs,
-                List.of(segments.get(segments.size() - 1)));
-    }
-
-    @Override
-    public Path getParent() {
-        if (segments.isEmpty()) {
-            return null;
-        }
-        return new AzureBlobPath(fs, segments.subList(0, segments.size() - 1));
-    }
-
-    @Override
-    public int getNameCount() {
-        return segments.size();
-    }
-
-    @Override
-    public Path getName(int index) {
-        return new AzureBlobPath(fs, List.of(segments.get(index)));
-    }
-
-    @Override
-    public Path subpath(int beginIndex, int endIndex) {
-        return new AzureBlobPath(
-                fs, new ArrayList<>(segments.subList(beginIndex, endIndex)));
-    }
-
-    @Override
-    public boolean startsWith(Path other) {
-        return other instanceof AzureBlobPath o && o.fs == fs
-                && segments.size() >= o.segments.size()
-                && segments.subList(0, o.segments.size()).equals(o.segments);
-    }
-
-    @Override
-    public boolean startsWith(String other) {
-        return startsWith(fs.getPath(other));
-    }
-
-    @Override
-    public boolean endsWith(Path other) {
-        return other instanceof AzureBlobPath o && o.fs == fs
-                && segments.size() >= o.segments.size()
-                && segments.subList(
-                        segments.size() - o.segments.size(), segments.size())
-                        .equals(o.segments);
-    }
-
-    @Override
-    public boolean endsWith(String other) {
-        return endsWith(fs.getPath(other));
-    }
-
-    @Override
-    public Path normalize() {
-        return this;
-    }
-
-    @Override
-    public Path resolve(Path other) {
-        if (!(other instanceof AzureBlobPath o)) {
-            throw new IllegalArgumentException(
-                    "Not an AzureBlobPath: " + other);
-        }
-        if (o.isAbsolute()) {
-            return o;
-        }
-        var combined = new ArrayList<>(segments);
-        combined.addAll(o.segments);
-        return new AzureBlobPath(fs, combined);
-    }
-
-    @Override
-    public Path resolve(String other) {
-        return resolve(fs.getPath(other));
-    }
-
-    @Override
-    public Path resolveSibling(Path other) {
-        var parent = getParent();
-        return parent == null ? other : parent.resolve(other);
-    }
-
-    @Override
-    public Path resolveSibling(String other) {
-        return resolveSibling(fs.getPath(other));
-    }
-
-    @Override
-    public Path relativize(Path other) {
-        if (!(other instanceof AzureBlobPath o) || o.fs != fs) {
-            throw new IllegalArgumentException(
-                    "Not an AzureBlobPath: " + other);
-        }
-        var common = 0;
-        while (common < segments.size() && common < o.segments.size()
-                && segments.get(common).equals(o.segments.get(common))) {
-            common++;
-        }
-        var result = new ArrayList<String>();
-        for (var i = common; i < segments.size(); i++) {
-            result.add("..");
-        }
-        result.addAll(o.segments.subList(common, o.segments.size()));
-        return new AzureBlobPath(fs, result);
+    protected Path createPath(List<String> segments) {
+        return new AzureBlobPath(fs, segments);
     }
 
     @Override
@@ -219,63 +76,5 @@ final class AzureBlobPath implements Path {
         } catch (URISyntaxException e) {
             throw new UncheckedIOException(new IOException(e));
         }
-    }
-
-    @Override
-    public Path toAbsolutePath() {
-        return this;
-    }
-
-    @Override
-    public Path toRealPath(LinkOption... options) {
-        return this;
-    }
-
-    @Override
-    public File toFile() {
-        throw new UnsupportedOperationException(
-                "Azure Blob paths have no local file representation.");
-    }
-
-    @Override
-    public WatchKey register(
-            WatchService watcher, Kind<?>[] events, Modifier... modifiers) {
-        throw new UnsupportedOperationException(
-                "Azure Blob paths do not support watching.");
-    }
-
-    @Override
-    public Iterator<Path> iterator() {
-        List<Path> names = new ArrayList<>();
-        for (var i = 0; i < segments.size(); i++) {
-            names.add(getName(i));
-        }
-        return names.iterator();
-    }
-
-    @Override
-    public int compareTo(Path other) {
-        return path().compareTo(((AzureBlobPath) other).path());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(fs, segments);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof AzureBlobPath other)) {
-            return false;
-        }
-        return fs == other.fs && segments.equals(other.segments);
-    }
-
-    @Override
-    public String toString() {
-        return path();
     }
 }

--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/cmis/CmisPath.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/cmis/CmisPath.java
@@ -14,58 +14,33 @@
  */
 package com.norconex.crawler.fs.fetch.impl.cmis;
 
-import java.io.File;
 import java.net.URI;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.nio.file.WatchEvent.Kind;
-import java.nio.file.WatchEvent.Modifier;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
+
+import com.norconex.crawler.fs.fetch.impl.ReadOnlyPath;
 
 /**
  * A path within a {@link CmisFileSystem}. Always absolute (all CMIS object
  * paths are rooted at {@code /}); relative-path support is limited to what
  * {@link #resolve(Path)} needs to build a child path from a path segment.
  */
-final class CmisPath implements Path {
+final class CmisPath extends ReadOnlyPath {
 
     private final CmisFileSystem fs;
-    private final List<String> segments;
 
     CmisPath(CmisFileSystem fs, String path) {
-        this(fs, parse(path));
+        this(fs, ReadOnlyPath.parse(path));
     }
 
     private CmisPath(CmisFileSystem fs, List<String> segments) {
+        super(fs, List.copyOf(segments), "CmisPath");
         this.fs = fs;
-        this.segments = segments;
-    }
-
-    private static List<String> parse(String path) {
-        List<String> result = new ArrayList<>();
-        for (String segment : path.split("/")) {
-            if (segment.isEmpty() || ".".equals(segment)) {
-                continue;
-            }
-            if ("..".equals(segment)) {
-                if (!result.isEmpty()) {
-                    result.remove(result.size() - 1);
-                }
-            } else {
-                result.add(segment);
-            }
-        }
-        return result;
     }
 
     /** The normalized, absolute, slash-separated CMIS object path. */
     String path() {
-        return "/" + String.join("/", segments);
+        return normalizedPath();
     }
 
     @Override
@@ -74,181 +49,12 @@ final class CmisPath implements Path {
     }
 
     @Override
-    public boolean isAbsolute() {
-        return true;
-    }
-
-    @Override
-    public Path getRoot() {
-        return new CmisPath(fs, List.of());
-    }
-
-    @Override
-    public Path getFileName() {
-        if (segments.isEmpty()) {
-            return null;
-        }
-        return new CmisPath(fs, List.of(segments.get(segments.size() - 1)));
-    }
-
-    @Override
-    public Path getParent() {
-        if (segments.isEmpty()) {
-            return null;
-        }
-        return new CmisPath(fs, segments.subList(0, segments.size() - 1));
-    }
-
-    @Override
-    public int getNameCount() {
-        return segments.size();
-    }
-
-    @Override
-    public Path getName(int index) {
-        return new CmisPath(fs, List.of(segments.get(index)));
-    }
-
-    @Override
-    public Path subpath(int beginIndex, int endIndex) {
-        return new CmisPath(
-                fs, new ArrayList<>(segments.subList(beginIndex, endIndex)));
-    }
-
-    @Override
-    public boolean startsWith(Path other) {
-        return other instanceof CmisPath o && o.fs == fs
-                && segments.size() >= o.segments.size()
-                && segments.subList(0, o.segments.size()).equals(o.segments);
-    }
-
-    @Override
-    public boolean startsWith(String other) {
-        return startsWith(fs.getPath(other));
-    }
-
-    @Override
-    public boolean endsWith(Path other) {
-        return other instanceof CmisPath o && o.fs == fs
-                && segments.size() >= o.segments.size()
-                && segments.subList(
-                        segments.size() - o.segments.size(), segments.size())
-                        .equals(o.segments);
-    }
-
-    @Override
-    public boolean endsWith(String other) {
-        return endsWith(fs.getPath(other));
-    }
-
-    @Override
-    public Path normalize() {
-        return this;
-    }
-
-    @Override
-    public Path resolve(Path other) {
-        if (!(other instanceof CmisPath o)) {
-            throw new IllegalArgumentException("Not a CmisPath: " + other);
-        }
-        if (o.isAbsolute()) {
-            return o;
-        }
-        var combined = new ArrayList<>(segments);
-        combined.addAll(o.segments);
-        return new CmisPath(fs, combined);
-    }
-
-    @Override
-    public Path resolve(String other) {
-        return resolve(fs.getPath(other));
-    }
-
-    @Override
-    public Path resolveSibling(Path other) {
-        var parent = getParent();
-        return parent == null ? other : parent.resolve(other);
-    }
-
-    @Override
-    public Path resolveSibling(String other) {
-        return resolveSibling(fs.getPath(other));
-    }
-
-    @Override
-    public Path relativize(Path other) {
-        if (!(other instanceof CmisPath o) || o.fs != fs) {
-            throw new IllegalArgumentException("Not a CmisPath: " + other);
-        }
-        var common = 0;
-        while (common < segments.size() && common < o.segments.size()
-                && segments.get(common).equals(o.segments.get(common))) {
-            common++;
-        }
-        var result = new ArrayList<String>();
-        for (var i = common; i < segments.size(); i++) {
-            result.add("..");
-        }
-        result.addAll(o.segments.subList(common, o.segments.size()));
-        return new CmisPath(fs, result);
+    protected Path createPath(List<String> segments) {
+        return new CmisPath(fs, segments);
     }
 
     @Override
     public URI toUri() {
         return URI.create("cmis:" + fs.endpointUrl() + "!" + path());
-    }
-
-    @Override
-    public Path toAbsolutePath() {
-        return this;
-    }
-
-    @Override
-    public Path toRealPath(LinkOption... options) {
-        return this;
-    }
-
-    @Override
-    public File toFile() {
-        throw new UnsupportedOperationException(
-                "CMIS paths have no local file representation.");
-    }
-
-    @Override
-    public WatchKey register(
-            WatchService watcher, Kind<?>[] events, Modifier... modifiers) {
-        throw new UnsupportedOperationException(
-                "CMIS paths do not support watching.");
-    }
-
-    @Override
-    public Iterator<Path> iterator() {
-        List<Path> names = new ArrayList<>();
-        for (var i = 0; i < segments.size(); i++) {
-            names.add(getName(i));
-        }
-        return names.iterator();
-    }
-
-    @Override
-    public int compareTo(Path other) {
-        return path().compareTo(((CmisPath) other).path());
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof CmisPath o
-                && fs == o.fs
-                && segments.equals(o.segments);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(fs, segments);
-    }
-
-    @Override
-    public String toString() {
-        return path();
     }
 }

--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/hdfs/HdfsPath.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/hdfs/HdfsPath.java
@@ -14,61 +14,36 @@
  */
 package com.norconex.crawler.fs.fetch.impl.hdfs;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.nio.file.WatchEvent.Kind;
-import java.nio.file.WatchEvent.Modifier;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
+
+import com.norconex.crawler.fs.fetch.impl.ReadOnlyPath;
 
 /**
  * A path within a {@link HdfsFileSystem}. Always absolute (all HDFS paths
  * are rooted at {@code /}); relative-path support is limited to what
  * {@link #resolve(Path)} needs to build a child path from a path segment.
  */
-final class HdfsPath implements Path {
+final class HdfsPath extends ReadOnlyPath {
 
     private final HdfsFileSystem fs;
-    private final List<String> segments;
 
     HdfsPath(HdfsFileSystem fs, String path) {
-        this(fs, parse(path));
+        this(fs, ReadOnlyPath.parse(path));
     }
 
     private HdfsPath(HdfsFileSystem fs, List<String> segments) {
+        super(fs, List.copyOf(segments), "HdfsPath");
         this.fs = fs;
-        this.segments = segments;
-    }
-
-    private static List<String> parse(String path) {
-        List<String> result = new ArrayList<>();
-        for (String segment : path.split("/")) {
-            if (segment.isEmpty() || ".".equals(segment)) {
-                continue;
-            }
-            if ("..".equals(segment)) {
-                if (!result.isEmpty()) {
-                    result.remove(result.size() - 1);
-                }
-            } else {
-                result.add(segment);
-            }
-        }
-        return result;
     }
 
     /** The normalized, absolute, slash-separated HDFS path. */
     String path() {
-        return "/" + String.join("/", segments);
+        return normalizedPath();
     }
 
     @Override
@@ -77,123 +52,8 @@ final class HdfsPath implements Path {
     }
 
     @Override
-    public boolean isAbsolute() {
-        return true;
-    }
-
-    @Override
-    public Path getRoot() {
-        return new HdfsPath(fs, List.of());
-    }
-
-    @Override
-    public Path getFileName() {
-        if (segments.isEmpty()) {
-            return null;
-        }
-        return new HdfsPath(fs, List.of(segments.get(segments.size() - 1)));
-    }
-
-    @Override
-    public Path getParent() {
-        if (segments.isEmpty()) {
-            return null;
-        }
-        return new HdfsPath(fs, segments.subList(0, segments.size() - 1));
-    }
-
-    @Override
-    public int getNameCount() {
-        return segments.size();
-    }
-
-    @Override
-    public Path getName(int index) {
-        return new HdfsPath(fs, List.of(segments.get(index)));
-    }
-
-    @Override
-    public Path subpath(int beginIndex, int endIndex) {
-        return new HdfsPath(
-                fs, new ArrayList<>(segments.subList(beginIndex, endIndex)));
-    }
-
-    @Override
-    public boolean startsWith(Path other) {
-        return other instanceof HdfsPath o && o.fs == fs
-                && segments.size() >= o.segments.size()
-                && segments.subList(0, o.segments.size()).equals(o.segments);
-    }
-
-    @Override
-    public boolean startsWith(String other) {
-        return startsWith(fs.getPath(other));
-    }
-
-    @Override
-    public boolean endsWith(Path other) {
-        return other instanceof HdfsPath o && o.fs == fs
-                && segments.size() >= o.segments.size()
-                && segments.subList(
-                        segments.size() - o.segments.size(), segments.size())
-                        .equals(o.segments);
-    }
-
-    @Override
-    public boolean endsWith(String other) {
-        return endsWith(fs.getPath(other));
-    }
-
-    @Override
-    public Path normalize() {
-        return this;
-    }
-
-    @Override
-    public Path resolve(Path other) {
-        if (!(other instanceof HdfsPath o)) {
-            throw new IllegalArgumentException("Not a HdfsPath: " + other);
-        }
-        if (o.isAbsolute()) {
-            return o;
-        }
-        var combined = new ArrayList<>(segments);
-        combined.addAll(o.segments);
-        return new HdfsPath(fs, combined);
-    }
-
-    @Override
-    public Path resolve(String other) {
-        return resolve(fs.getPath(other));
-    }
-
-    @Override
-    public Path resolveSibling(Path other) {
-        var parent = getParent();
-        return parent == null ? other : parent.resolve(other);
-    }
-
-    @Override
-    public Path resolveSibling(String other) {
-        return resolveSibling(fs.getPath(other));
-    }
-
-    @Override
-    public Path relativize(Path other) {
-        if (!(other instanceof HdfsPath o) || o.fs != fs) {
-            throw new IllegalArgumentException("Not a HdfsPath: " + other);
-        }
-        var common = 0;
-        while (common < segments.size() && common < o.segments.size()
-                && segments.get(common).equals(o.segments.get(common))) {
-            common++;
-        }
-        var result = new ArrayList<String>();
-        for (var i = common; i < segments.size(); i++) {
-            result.add("..");
-        }
-        result.addAll(o.segments.subList(common, o.segments.size()));
-        return new HdfsPath(fs, result);
+    protected Path createPath(List<String> segments) {
+        return new HdfsPath(fs, segments);
     }
 
     @Override
@@ -205,59 +65,5 @@ final class HdfsPath implements Path {
         } catch (URISyntaxException e) {
             throw new UncheckedIOException(new IOException(e));
         }
-    }
-
-    @Override
-    public Path toAbsolutePath() {
-        return this;
-    }
-
-    @Override
-    public Path toRealPath(LinkOption... options) {
-        return this;
-    }
-
-    @Override
-    public File toFile() {
-        throw new UnsupportedOperationException(
-                "HDFS paths have no local file representation.");
-    }
-
-    @Override
-    public WatchKey register(
-            WatchService watcher, Kind<?>[] events, Modifier... modifiers) {
-        throw new UnsupportedOperationException(
-                "HDFS paths do not support watching.");
-    }
-
-    @Override
-    public Iterator<Path> iterator() {
-        List<Path> names = new ArrayList<>();
-        for (var i = 0; i < segments.size(); i++) {
-            names.add(getName(i));
-        }
-        return names.iterator();
-    }
-
-    @Override
-    public int compareTo(Path other) {
-        return path().compareTo(((HdfsPath) other).path());
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof HdfsPath o
-                && fs == o.fs
-                && segments.equals(o.segments);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(fs, segments);
-    }
-
-    @Override
-    public String toString() {
-        return path();
     }
 }

--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/s3/S3Path.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/s3/S3Path.java
@@ -14,21 +14,14 @@
  */
 package com.norconex.crawler.fs.fetch.impl.s3;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.nio.file.WatchEvent.Kind;
-import java.nio.file.WatchEvent.Modifier;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
+
+import com.norconex.crawler.fs.fetch.impl.ReadOnlyPath;
 
 /**
  * A path within an {@link S3FileSystem} (a bucket). Always absolute (all
@@ -36,40 +29,22 @@ import java.util.Objects;
  * support is limited to what {@link #resolve(Path)} needs to build a child
  * path from a path segment.
  */
-final class S3Path implements Path {
+final class S3Path extends ReadOnlyPath {
 
     private final S3FileSystem fs;
-    private final List<String> segments;
 
     S3Path(S3FileSystem fs, String path) {
-        this(fs, parse(path));
+        this(fs, ReadOnlyPath.parse(path));
     }
 
     private S3Path(S3FileSystem fs, List<String> segments) {
+        super(fs, List.copyOf(segments), "S3Path");
         this.fs = fs;
-        this.segments = segments;
-    }
-
-    private static List<String> parse(String path) {
-        List<String> result = new ArrayList<>();
-        for (String segment : path.split("/")) {
-            if (segment.isEmpty() || ".".equals(segment)) {
-                continue;
-            }
-            if ("..".equals(segment)) {
-                if (!result.isEmpty()) {
-                    result.remove(result.size() - 1);
-                }
-            } else {
-                result.add(segment);
-            }
-        }
-        return result;
     }
 
     /** The normalized, absolute, slash-separated path. */
     String path() {
-        return "/" + String.join("/", segments);
+        return normalizedPath();
     }
 
     /**
@@ -77,7 +52,7 @@ final class S3Path implements Path {
      * the bucket root).
      */
     String key() {
-        return String.join("/", segments);
+        return String.join("/", segments());
     }
 
     /** This path's key with a trailing slash, used to list it as a prefix. */
@@ -92,123 +67,8 @@ final class S3Path implements Path {
     }
 
     @Override
-    public boolean isAbsolute() {
-        return true;
-    }
-
-    @Override
-    public Path getRoot() {
-        return new S3Path(fs, List.of());
-    }
-
-    @Override
-    public Path getFileName() {
-        if (segments.isEmpty()) {
-            return null;
-        }
-        return new S3Path(fs, List.of(segments.get(segments.size() - 1)));
-    }
-
-    @Override
-    public Path getParent() {
-        if (segments.isEmpty()) {
-            return null;
-        }
-        return new S3Path(fs, segments.subList(0, segments.size() - 1));
-    }
-
-    @Override
-    public int getNameCount() {
-        return segments.size();
-    }
-
-    @Override
-    public Path getName(int index) {
-        return new S3Path(fs, List.of(segments.get(index)));
-    }
-
-    @Override
-    public Path subpath(int beginIndex, int endIndex) {
-        return new S3Path(
-                fs, new ArrayList<>(segments.subList(beginIndex, endIndex)));
-    }
-
-    @Override
-    public boolean startsWith(Path other) {
-        return other instanceof S3Path o && o.fs == fs
-                && segments.size() >= o.segments.size()
-                && segments.subList(0, o.segments.size()).equals(o.segments);
-    }
-
-    @Override
-    public boolean startsWith(String other) {
-        return startsWith(fs.getPath(other));
-    }
-
-    @Override
-    public boolean endsWith(Path other) {
-        return other instanceof S3Path o && o.fs == fs
-                && segments.size() >= o.segments.size()
-                && segments.subList(
-                        segments.size() - o.segments.size(), segments.size())
-                        .equals(o.segments);
-    }
-
-    @Override
-    public boolean endsWith(String other) {
-        return endsWith(fs.getPath(other));
-    }
-
-    @Override
-    public Path normalize() {
-        return this;
-    }
-
-    @Override
-    public Path resolve(Path other) {
-        if (!(other instanceof S3Path o)) {
-            throw new IllegalArgumentException("Not a S3Path: " + other);
-        }
-        if (o.isAbsolute()) {
-            return o;
-        }
-        var combined = new ArrayList<>(segments);
-        combined.addAll(o.segments);
-        return new S3Path(fs, combined);
-    }
-
-    @Override
-    public Path resolve(String other) {
-        return resolve(fs.getPath(other));
-    }
-
-    @Override
-    public Path resolveSibling(Path other) {
-        var parent = getParent();
-        return parent == null ? other : parent.resolve(other);
-    }
-
-    @Override
-    public Path resolveSibling(String other) {
-        return resolveSibling(fs.getPath(other));
-    }
-
-    @Override
-    public Path relativize(Path other) {
-        if (!(other instanceof S3Path o) || o.fs != fs) {
-            throw new IllegalArgumentException("Not a S3Path: " + other);
-        }
-        var common = 0;
-        while (common < segments.size() && common < o.segments.size()
-                && segments.get(common).equals(o.segments.get(common))) {
-            common++;
-        }
-        var result = new ArrayList<String>();
-        for (var i = common; i < segments.size(); i++) {
-            result.add("..");
-        }
-        result.addAll(o.segments.subList(common, o.segments.size()));
-        return new S3Path(fs, result);
+    protected Path createPath(List<String> segments) {
+        return new S3Path(fs, segments);
     }
 
     @Override
@@ -219,59 +79,5 @@ final class S3Path implements Path {
         } catch (URISyntaxException e) {
             throw new UncheckedIOException(new IOException(e));
         }
-    }
-
-    @Override
-    public Path toAbsolutePath() {
-        return this;
-    }
-
-    @Override
-    public Path toRealPath(LinkOption... options) {
-        return this;
-    }
-
-    @Override
-    public File toFile() {
-        throw new UnsupportedOperationException(
-                "S3 paths have no local file representation.");
-    }
-
-    @Override
-    public WatchKey register(
-            WatchService watcher, Kind<?>[] events, Modifier... modifiers) {
-        throw new UnsupportedOperationException(
-                "S3 paths do not support watching.");
-    }
-
-    @Override
-    public Iterator<Path> iterator() {
-        List<Path> names = new ArrayList<>();
-        for (var i = 0; i < segments.size(); i++) {
-            names.add(getName(i));
-        }
-        return names.iterator();
-    }
-
-    @Override
-    public int compareTo(Path other) {
-        return path().compareTo(((S3Path) other).path());
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof S3Path o
-                && fs == o.fs
-                && segments.equals(o.segments);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(fs, segments);
-    }
-
-    @Override
-    public String toString() {
-        return path();
     }
 }

--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/smb/SmbPath.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/smb/SmbPath.java
@@ -14,21 +14,14 @@
  */
 package com.norconex.crawler.fs.fetch.impl.smb;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.nio.file.WatchEvent.Kind;
-import java.nio.file.WatchEvent.Modifier;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
+
+import com.norconex.crawler.fs.fetch.impl.ReadOnlyPath;
 
 /**
  * A path within a {@link SmbFileSystem}. Always absolute (all SMB resource
@@ -36,40 +29,22 @@ import java.util.Objects;
  * segment); relative-path support is limited to what {@link #resolve(Path)}
  * needs to build a child path from a path segment.
  */
-final class SmbPath implements Path {
+final class SmbPath extends ReadOnlyPath {
 
     private final SmbFileSystem fs;
-    private final List<String> segments;
 
     SmbPath(SmbFileSystem fs, String path) {
-        this(fs, parse(path));
+        this(fs, ReadOnlyPath.parse(path));
     }
 
     private SmbPath(SmbFileSystem fs, List<String> segments) {
+        super(fs, List.copyOf(segments), "SmbPath");
         this.fs = fs;
-        this.segments = segments;
-    }
-
-    private static List<String> parse(String path) {
-        List<String> result = new ArrayList<>();
-        for (String segment : path.split("/")) {
-            if (segment.isEmpty() || ".".equals(segment)) {
-                continue;
-            }
-            if ("..".equals(segment)) {
-                if (!result.isEmpty()) {
-                    result.remove(result.size() - 1);
-                }
-            } else {
-                result.add(segment);
-            }
-        }
-        return result;
     }
 
     /** The normalized, absolute, slash-separated SMB resource path. */
     String path() {
-        return "/" + String.join("/", segments);
+        return normalizedPath();
     }
 
     @Override
@@ -78,123 +53,8 @@ final class SmbPath implements Path {
     }
 
     @Override
-    public boolean isAbsolute() {
-        return true;
-    }
-
-    @Override
-    public Path getRoot() {
-        return new SmbPath(fs, List.of());
-    }
-
-    @Override
-    public Path getFileName() {
-        if (segments.isEmpty()) {
-            return null;
-        }
-        return new SmbPath(fs, List.of(segments.get(segments.size() - 1)));
-    }
-
-    @Override
-    public Path getParent() {
-        if (segments.isEmpty()) {
-            return null;
-        }
-        return new SmbPath(fs, segments.subList(0, segments.size() - 1));
-    }
-
-    @Override
-    public int getNameCount() {
-        return segments.size();
-    }
-
-    @Override
-    public Path getName(int index) {
-        return new SmbPath(fs, List.of(segments.get(index)));
-    }
-
-    @Override
-    public Path subpath(int beginIndex, int endIndex) {
-        return new SmbPath(
-                fs, new ArrayList<>(segments.subList(beginIndex, endIndex)));
-    }
-
-    @Override
-    public boolean startsWith(Path other) {
-        return other instanceof SmbPath o && o.fs == fs
-                && segments.size() >= o.segments.size()
-                && segments.subList(0, o.segments.size()).equals(o.segments);
-    }
-
-    @Override
-    public boolean startsWith(String other) {
-        return startsWith(fs.getPath(other));
-    }
-
-    @Override
-    public boolean endsWith(Path other) {
-        return other instanceof SmbPath o && o.fs == fs
-                && segments.size() >= o.segments.size()
-                && segments.subList(
-                        segments.size() - o.segments.size(), segments.size())
-                        .equals(o.segments);
-    }
-
-    @Override
-    public boolean endsWith(String other) {
-        return endsWith(fs.getPath(other));
-    }
-
-    @Override
-    public Path normalize() {
-        return this;
-    }
-
-    @Override
-    public Path resolve(Path other) {
-        if (!(other instanceof SmbPath o)) {
-            throw new IllegalArgumentException("Not a SmbPath: " + other);
-        }
-        if (o.isAbsolute()) {
-            return o;
-        }
-        var combined = new ArrayList<>(segments);
-        combined.addAll(o.segments);
-        return new SmbPath(fs, combined);
-    }
-
-    @Override
-    public Path resolve(String other) {
-        return resolve(fs.getPath(other));
-    }
-
-    @Override
-    public Path resolveSibling(Path other) {
-        var parent = getParent();
-        return parent == null ? other : parent.resolve(other);
-    }
-
-    @Override
-    public Path resolveSibling(String other) {
-        return resolveSibling(fs.getPath(other));
-    }
-
-    @Override
-    public Path relativize(Path other) {
-        if (!(other instanceof SmbPath o) || o.fs != fs) {
-            throw new IllegalArgumentException("Not a SmbPath: " + other);
-        }
-        var common = 0;
-        while (common < segments.size() && common < o.segments.size()
-                && segments.get(common).equals(o.segments.get(common))) {
-            common++;
-        }
-        var result = new ArrayList<String>();
-        for (var i = common; i < segments.size(); i++) {
-            result.add("..");
-        }
-        result.addAll(o.segments.subList(common, o.segments.size()));
-        return new SmbPath(fs, result);
+    protected Path createPath(List<String> segments) {
+        return new SmbPath(fs, segments);
     }
 
     @Override
@@ -205,59 +65,5 @@ final class SmbPath implements Path {
         } catch (URISyntaxException e) {
             throw new UncheckedIOException(new IOException(e));
         }
-    }
-
-    @Override
-    public Path toAbsolutePath() {
-        return this;
-    }
-
-    @Override
-    public Path toRealPath(LinkOption... options) {
-        return this;
-    }
-
-    @Override
-    public File toFile() {
-        throw new UnsupportedOperationException(
-                "SMB paths have no local file representation.");
-    }
-
-    @Override
-    public WatchKey register(
-            WatchService watcher, Kind<?>[] events, Modifier... modifiers) {
-        throw new UnsupportedOperationException(
-                "SMB paths do not support watching.");
-    }
-
-    @Override
-    public Iterator<Path> iterator() {
-        List<Path> names = new ArrayList<>();
-        for (var i = 0; i < segments.size(); i++) {
-            names.add(getName(i));
-        }
-        return names.iterator();
-    }
-
-    @Override
-    public int compareTo(Path other) {
-        return path().compareTo(((SmbPath) other).path());
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof SmbPath o
-                && fs == o.fs
-                && segments.equals(o.segments);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(fs, segments);
-    }
-
-    @Override
-    public String toString() {
-        return path();
     }
 }

--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/webdav/WebDavPath.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/webdav/WebDavPath.java
@@ -14,21 +14,14 @@
  */
 package com.norconex.crawler.fs.fetch.impl.webdav;
 
-import java.io.File;
-import java.io.UncheckedIOException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.nio.file.WatchEvent.Kind;
-import java.nio.file.WatchEvent.Modifier;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
+
+import com.norconex.crawler.fs.fetch.impl.ReadOnlyPath;
 
 /**
  * A path within a {@link WebDavFileSystem}. Always absolute (all WebDAV
@@ -36,40 +29,22 @@ import java.util.Objects;
  * limited to what {@link #resolve(Path)} needs to build a child path from
  * a path segment.
  */
-final class WebDavPath implements Path {
+final class WebDavPath extends ReadOnlyPath {
 
     private final WebDavFileSystem fs;
-    private final List<String> segments;
 
     WebDavPath(WebDavFileSystem fs, String path) {
-        this(fs, parse(path));
+        this(fs, ReadOnlyPath.parse(path));
     }
 
     private WebDavPath(WebDavFileSystem fs, List<String> segments) {
+        super(fs, List.copyOf(segments), "WebDavPath");
         this.fs = fs;
-        this.segments = segments;
-    }
-
-    private static List<String> parse(String path) {
-        List<String> result = new ArrayList<>();
-        for (String segment : path.split("/")) {
-            if (segment.isEmpty() || ".".equals(segment)) {
-                continue;
-            }
-            if ("..".equals(segment)) {
-                if (!result.isEmpty()) {
-                    result.remove(result.size() - 1);
-                }
-            } else {
-                result.add(segment);
-            }
-        }
-        return result;
     }
 
     /** The normalized, absolute, slash-separated WebDAV resource path. */
     String path() {
-        return "/" + String.join("/", segments);
+        return normalizedPath();
     }
 
     @Override
@@ -78,123 +53,8 @@ final class WebDavPath implements Path {
     }
 
     @Override
-    public boolean isAbsolute() {
-        return true;
-    }
-
-    @Override
-    public Path getRoot() {
-        return new WebDavPath(fs, List.of());
-    }
-
-    @Override
-    public Path getFileName() {
-        if (segments.isEmpty()) {
-            return null;
-        }
-        return new WebDavPath(fs, List.of(segments.get(segments.size() - 1)));
-    }
-
-    @Override
-    public Path getParent() {
-        if (segments.isEmpty()) {
-            return null;
-        }
-        return new WebDavPath(fs, segments.subList(0, segments.size() - 1));
-    }
-
-    @Override
-    public int getNameCount() {
-        return segments.size();
-    }
-
-    @Override
-    public Path getName(int index) {
-        return new WebDavPath(fs, List.of(segments.get(index)));
-    }
-
-    @Override
-    public Path subpath(int beginIndex, int endIndex) {
-        return new WebDavPath(
-                fs, new ArrayList<>(segments.subList(beginIndex, endIndex)));
-    }
-
-    @Override
-    public boolean startsWith(Path other) {
-        return other instanceof WebDavPath o && o.fs == fs
-                && segments.size() >= o.segments.size()
-                && segments.subList(0, o.segments.size()).equals(o.segments);
-    }
-
-    @Override
-    public boolean startsWith(String other) {
-        return startsWith(fs.getPath(other));
-    }
-
-    @Override
-    public boolean endsWith(Path other) {
-        return other instanceof WebDavPath o && o.fs == fs
-                && segments.size() >= o.segments.size()
-                && segments.subList(
-                        segments.size() - o.segments.size(), segments.size())
-                        .equals(o.segments);
-    }
-
-    @Override
-    public boolean endsWith(String other) {
-        return endsWith(fs.getPath(other));
-    }
-
-    @Override
-    public Path normalize() {
-        return this;
-    }
-
-    @Override
-    public Path resolve(Path other) {
-        if (!(other instanceof WebDavPath o)) {
-            throw new IllegalArgumentException("Not a WebDavPath: " + other);
-        }
-        if (o.isAbsolute()) {
-            return o;
-        }
-        var combined = new ArrayList<>(segments);
-        combined.addAll(o.segments);
-        return new WebDavPath(fs, combined);
-    }
-
-    @Override
-    public Path resolve(String other) {
-        return resolve(fs.getPath(other));
-    }
-
-    @Override
-    public Path resolveSibling(Path other) {
-        var parent = getParent();
-        return parent == null ? other : parent.resolve(other);
-    }
-
-    @Override
-    public Path resolveSibling(String other) {
-        return resolveSibling(fs.getPath(other));
-    }
-
-    @Override
-    public Path relativize(Path other) {
-        if (!(other instanceof WebDavPath o) || o.fs != fs) {
-            throw new IllegalArgumentException("Not a WebDavPath: " + other);
-        }
-        var common = 0;
-        while (common < segments.size() && common < o.segments.size()
-                && segments.get(common).equals(o.segments.get(common))) {
-            common++;
-        }
-        var result = new ArrayList<String>();
-        for (var i = common; i < segments.size(); i++) {
-            result.add("..");
-        }
-        result.addAll(o.segments.subList(common, o.segments.size()));
-        return new WebDavPath(fs, result);
+    protected Path createPath(List<String> segments) {
+        return new WebDavPath(fs, segments);
     }
 
     @Override
@@ -206,59 +66,5 @@ final class WebDavPath implements Path {
         } catch (URISyntaxException e) {
             throw new UncheckedIOException(new IOException(e));
         }
-    }
-
-    @Override
-    public Path toAbsolutePath() {
-        return this;
-    }
-
-    @Override
-    public Path toRealPath(LinkOption... options) {
-        return this;
-    }
-
-    @Override
-    public File toFile() {
-        throw new UnsupportedOperationException(
-                "WebDAV paths have no local file representation.");
-    }
-
-    @Override
-    public WatchKey register(
-            WatchService watcher, Kind<?>[] events, Modifier... modifiers) {
-        throw new UnsupportedOperationException(
-                "WebDAV paths do not support watching.");
-    }
-
-    @Override
-    public Iterator<Path> iterator() {
-        List<Path> names = new ArrayList<>();
-        for (var i = 0; i < segments.size(); i++) {
-            names.add(getName(i));
-        }
-        return names.iterator();
-    }
-
-    @Override
-    public int compareTo(Path other) {
-        return path().compareTo(((WebDavPath) other).path());
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof WebDavPath o
-                && fs == o.fs
-                && segments.equals(o.segments);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(fs, segments);
-    }
-
-    @Override
-    public String toString() {
-        return path();
     }
 }


### PR DESCRIPTION
- Introduced a new abstract class ReadOnlyPath to encapsulate common behavior for remote, read-only file systems.
- Updated CmisPath, HdfsPath, S3Path, SmbPath, and WebDavPath to extend ReadOnlyPath, reducing code duplication.
- Removed redundant path parsing logic from individual path classes, leveraging the new parse method in ReadOnlyPath.
- Simplified path normalization and segment handling by utilizing methods from ReadOnlyPath.
- Ensured all path classes maintain their absolute path characteristics while adhering to the new structure.

Signed-off-by: Pascal Essiembre <pascal.essiembre@norconex.com>

## Description

<!-- Describe the changes in this pull request. -->

## Motivation & Context

<!-- Why is this change needed? What problem does it solve? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Internal/maintenance (CI, formatting, refactoring with no user impact)

## Contributor Agreement

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the DCO
- [ ] All commits in this PR are signed off (`-s`) and GPG-signed (`-S`)

## Testing

<!-- How has this been tested? -->

## Release Notes

**If this PR will be included in an upcoming release, describe the user-facing change here (1-2 lines):**

<!-- Example:
"Fixed URL encoding in query parameters (fixes #123)"
or
"Added support for parallel processing with new maxThreads configuration"
-->

---

**Note:** When a release is prepared, the changelog file will be built from merged PRs and the release notes provided above.
