### PR TITLE
Refactor file system providers to extend a new ReadOnlyFileSystemProvider

### DIFF
--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/ReadOnlyFileSystemProvider.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/ReadOnlyFileSystemProvider.java
@@ -1,0 +1,210 @@
+/* Copyright 2026 Norconex Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.norconex.crawler.fs.fetch.impl;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.NonWritableChannelException;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.AccessMode;
+import java.nio.file.CopyOption;
+import java.nio.file.FileStore;
+import java.nio.file.LinkOption;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.FileAttributeView;
+import java.nio.file.attribute.FileTime;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Common read-only {@link FileSystemProvider} behavior shared by cloud and
+ * remote filesystem providers.
+ */
+public abstract class ReadOnlyFileSystemProvider extends FileSystemProvider {
+
+    protected abstract String fileSystemLabel();
+
+    @Override
+    public final SeekableByteChannel newByteChannel(
+            Path path, Set<? extends OpenOption> options,
+            FileAttribute<?>... attrs) throws IOException {
+        byte[] content;
+        try (var is = newInputStream(path)) {
+            content = is.readAllBytes();
+        }
+        return new InMemoryReadOnlySeekableByteChannel(content);
+    }
+
+    @Override
+    public final Map<String, Object> readAttributes(
+            Path path, String attributes, LinkOption... options) {
+        throw new UnsupportedOperationException(
+                "Attribute-name based reads are not supported;"
+                        + " use readAttributes(Path, Class).");
+    }
+
+    @Override
+    public final <V extends FileAttributeView> V getFileAttributeView(
+            Path path, Class<V> type, LinkOption... options) {
+        if (type == BasicFileAttributeView.class) {
+            return type.cast(new BasicFileAttributeView() {
+                @Override
+                public String name() {
+                    return "basic";
+                }
+
+                @Override
+                public BasicFileAttributes readAttributes()
+                        throws IOException {
+                    return ReadOnlyFileSystemProvider.this.readAttributes(
+                            path, BasicFileAttributes.class);
+                }
+
+                @Override
+                public void setTimes(
+                        FileTime lastModifiedTime, FileTime lastAccessTime,
+                        FileTime createTime) {
+                    throw readOnlyException();
+                }
+            });
+        }
+        return null;
+    }
+
+    @Override
+    public final void checkAccess(Path path, AccessMode... modes)
+            throws IOException {
+        readAttributes(path, BasicFileAttributes.class);
+        for (var mode : modes) {
+            if (mode == AccessMode.WRITE || mode == AccessMode.EXECUTE) {
+                throw new AccessDeniedException(path.toString());
+            }
+        }
+    }
+
+    @Override
+    public final boolean isSameFile(Path path, Path path2) {
+        return path.equals(path2);
+    }
+
+    @Override
+    public final boolean isHidden(Path path) {
+        return false;
+    }
+
+    @Override
+    public final FileStore getFileStore(Path path) {
+        throw new UnsupportedOperationException(
+                fileSystemLabel() + " file systems do not expose file stores.");
+    }
+
+    @Override
+    public final void createDirectory(Path dir, FileAttribute<?>... attrs) {
+        throw readOnlyException();
+    }
+
+    @Override
+    public final void delete(Path path) {
+        throw readOnlyException();
+    }
+
+    @Override
+    public final void copy(Path source, Path target, CopyOption... options) {
+        throw readOnlyException();
+    }
+
+    @Override
+    public final void move(Path source, Path target, CopyOption... options) {
+        throw readOnlyException();
+    }
+
+    @Override
+    public final void setAttribute(
+            Path path, String attribute, Object value,
+            LinkOption... options) {
+        throw readOnlyException();
+    }
+
+    private UnsupportedOperationException readOnlyException() {
+        return new UnsupportedOperationException(
+                fileSystemLabel() + " file systems are read-only.");
+    }
+
+    private static final class InMemoryReadOnlySeekableByteChannel
+            implements SeekableByteChannel {
+
+        private final ByteBuffer buffer;
+        private boolean open = true;
+
+        InMemoryReadOnlySeekableByteChannel(byte[] content) {
+            this.buffer = ByteBuffer.wrap(content);
+        }
+
+        @Override
+        public int read(ByteBuffer dst) {
+            if (!buffer.hasRemaining()) {
+                return -1;
+            }
+            var count = Math.min(dst.remaining(), buffer.remaining());
+            var slice = buffer.slice();
+            slice.limit(count);
+            dst.put(slice);
+            buffer.position(buffer.position() + count);
+            return count;
+        }
+
+        @Override
+        public int write(ByteBuffer src) {
+            throw new NonWritableChannelException();
+        }
+
+        @Override
+        public long position() {
+            return buffer.position();
+        }
+
+        @Override
+        public SeekableByteChannel position(long newPosition) {
+            buffer.position((int) newPosition);
+            return this;
+        }
+
+        @Override
+        public long size() {
+            return buffer.limit();
+        }
+
+        @Override
+        public SeekableByteChannel truncate(long size) {
+            throw new NonWritableChannelException();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return open;
+        }
+
+        @Override
+        public void close() {
+            open = false;
+        }
+    }
+}

--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/adlsgen2/AdlsGen2FileSystemProvider.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/adlsgen2/AdlsGen2FileSystemProvider.java
@@ -17,25 +17,15 @@ package com.norconex.crawler.fs.fetch.impl.adlsgen2;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.nio.ByteBuffer;
-import java.nio.channels.NonWritableChannelException;
-import java.nio.channels.SeekableByteChannel;
-import java.nio.file.AccessDeniedException;
-import java.nio.file.AccessMode;
-import java.nio.file.CopyOption;
 import java.nio.file.DirectoryStream;
 import java.nio.file.DirectoryStream.Filter;
-import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.nio.file.spi.FileSystemProvider;
 import java.time.OffsetDateTime;
@@ -43,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -59,6 +48,7 @@ import com.azure.storage.file.datalake.models.PathItem;
 import com.azure.storage.file.datalake.models.PathProperties;
 import com.norconex.commons.lang.map.Properties;
 import com.norconex.crawler.fs.doc.FsDocMetadata;
+import com.norconex.crawler.fs.fetch.impl.ReadOnlyFileSystemProvider;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -66,7 +56,7 @@ import lombok.extern.slf4j.Slf4j;
  * A read-only NIO.2 {@link FileSystemProvider} for ADLS Gen2.
  */
 @Slf4j
-final class AdlsGen2FileSystemProvider extends FileSystemProvider {
+final class AdlsGen2FileSystemProvider extends ReadOnlyFileSystemProvider {
 
     private static final int HTTP_NOT_FOUND = 404;
 
@@ -81,6 +71,11 @@ final class AdlsGen2FileSystemProvider extends FileSystemProvider {
     @Override
     public String getScheme() {
         return "abfss";
+    }
+
+    @Override
+    protected String fileSystemLabel() {
+        return "ADLS Gen2";
     }
 
     @Override
@@ -144,17 +139,6 @@ final class AdlsGen2FileSystemProvider extends FileSystemProvider {
             throw new IOException(
                     "Could not read ADLS Gen2 file: " + adlsPath.path(), e);
         }
-    }
-
-    @Override
-    public SeekableByteChannel newByteChannel(
-            Path path, Set<? extends OpenOption> options,
-            FileAttribute<?>... attrs) throws IOException {
-        byte[] content;
-        try (var is = newInputStream(path)) {
-            content = is.readAllBytes();
-        }
-        return new InMemorySeekableByteChannel(content);
     }
 
     @Override
@@ -351,159 +335,4 @@ final class AdlsGen2FileSystemProvider extends FileSystemProvider {
         }
     }
 
-    @Override
-    public Map<String, Object> readAttributes(
-            Path path, String attributes, LinkOption... options) {
-        throw new UnsupportedOperationException(
-                "Attribute-name based reads are not supported;"
-                        + " use readAttributes(Path, Class).");
-    }
-
-    @Override
-    public <V extends FileAttributeView> V getFileAttributeView(
-            Path path, Class<V> type, LinkOption... options) {
-        if (type == BasicFileAttributeView.class) {
-            return type.cast(new BasicFileAttributeView() {
-                @Override
-                public String name() {
-                    return "basic";
-                }
-
-                @Override
-                public BasicFileAttributes readAttributes()
-                        throws IOException {
-                    return AdlsGen2FileSystemProvider.this.readAttributes(
-                            path, BasicFileAttributes.class);
-                }
-
-                @Override
-                public void setTimes(
-                        FileTime lastModifiedTime, FileTime lastAccessTime,
-                        FileTime createTime) {
-                    throw new UnsupportedOperationException(
-                            "ADLS Gen2 file systems are read-only.");
-                }
-            });
-        }
-        return null;
-    }
-
-    @Override
-    public void checkAccess(Path path, AccessMode... modes)
-            throws IOException {
-        readAttributes(path, BasicFileAttributes.class);
-        for (var mode : modes) {
-            if (mode == AccessMode.WRITE || mode == AccessMode.EXECUTE) {
-                throw new AccessDeniedException(path.toString());
-            }
-        }
-    }
-
-    @Override
-    public boolean isSameFile(Path path, Path path2) {
-        return path.equals(path2);
-    }
-
-    @Override
-    public boolean isHidden(Path path) {
-        return false;
-    }
-
-    @Override
-    public FileStore getFileStore(Path path) {
-        throw new UnsupportedOperationException(
-                "ADLS Gen2 file systems do not expose file stores.");
-    }
-
-    @Override
-    public void createDirectory(Path dir, FileAttribute<?>... attrs) {
-        throw new UnsupportedOperationException(
-                "ADLS Gen2 file systems are read-only.");
-    }
-
-    @Override
-    public void delete(Path path) {
-        throw new UnsupportedOperationException(
-                "ADLS Gen2 file systems are read-only.");
-    }
-
-    @Override
-    public void copy(Path source, Path target, CopyOption... options) {
-        throw new UnsupportedOperationException(
-                "ADLS Gen2 file systems are read-only.");
-    }
-
-    @Override
-    public void move(Path source, Path target, CopyOption... options) {
-        throw new UnsupportedOperationException(
-                "ADLS Gen2 file systems are read-only.");
-    }
-
-    @Override
-    public void setAttribute(
-            Path path, String attribute, Object value,
-            LinkOption... options) {
-        throw new UnsupportedOperationException(
-                "ADLS Gen2 file systems are read-only.");
-    }
-
-    private static final class InMemorySeekableByteChannel
-            implements SeekableByteChannel {
-
-        private final ByteBuffer buffer;
-        private boolean open = true;
-
-        InMemorySeekableByteChannel(byte[] content) {
-            buffer = ByteBuffer.wrap(content);
-        }
-
-        @Override
-        public int read(ByteBuffer dst) {
-            if (!buffer.hasRemaining()) {
-                return -1;
-            }
-            var count = Math.min(dst.remaining(), buffer.remaining());
-            var slice = buffer.slice();
-            slice.limit(count);
-            dst.put(slice);
-            buffer.position(buffer.position() + count);
-            return count;
-        }
-
-        @Override
-        public int write(ByteBuffer src) {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public long position() {
-            return buffer.position();
-        }
-
-        @Override
-        public SeekableByteChannel position(long newPosition) {
-            buffer.position((int) newPosition);
-            return this;
-        }
-
-        @Override
-        public long size() {
-            return buffer.limit();
-        }
-
-        @Override
-        public SeekableByteChannel truncate(long size) {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public boolean isOpen() {
-            return open;
-        }
-
-        @Override
-        public void close() {
-            open = false;
-        }
-    }
 }

--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/azureblob/AzureBlobFileSystemProvider.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/azureblob/AzureBlobFileSystemProvider.java
@@ -17,25 +17,15 @@ package com.norconex.crawler.fs.fetch.impl.azureblob;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.nio.ByteBuffer;
-import java.nio.channels.NonWritableChannelException;
-import java.nio.channels.SeekableByteChannel;
-import java.nio.file.AccessDeniedException;
-import java.nio.file.AccessMode;
-import java.nio.file.CopyOption;
 import java.nio.file.DirectoryStream;
 import java.nio.file.DirectoryStream.Filter;
-import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.nio.file.spi.FileSystemProvider;
 import java.time.OffsetDateTime;
@@ -43,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
@@ -54,6 +43,7 @@ import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.models.BlobItemProperties;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.ListBlobsOptions;
+import com.norconex.crawler.fs.fetch.impl.ReadOnlyFileSystemProvider;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -61,7 +51,7 @@ import lombok.extern.slf4j.Slf4j;
  * A read-only NIO.2 {@link FileSystemProvider} for Azure Blob Storage.
  */
 @Slf4j
-final class AzureBlobFileSystemProvider extends FileSystemProvider {
+final class AzureBlobFileSystemProvider extends ReadOnlyFileSystemProvider {
 
     private static final int HTTP_NOT_FOUND = 404;
 
@@ -71,6 +61,11 @@ final class AzureBlobFileSystemProvider extends FileSystemProvider {
     @Override
     public String getScheme() {
         return "azblob";
+    }
+
+    @Override
+    protected String fileSystemLabel() {
+        return "Azure Blob";
     }
 
     @Override
@@ -133,17 +128,6 @@ final class AzureBlobFileSystemProvider extends FileSystemProvider {
             throw new IOException(
                     "Could not read Azure blob: " + blobPath.path(), e);
         }
-    }
-
-    @Override
-    public SeekableByteChannel newByteChannel(
-            Path path, Set<? extends OpenOption> options,
-            FileAttribute<?>... attrs) throws IOException {
-        byte[] content;
-        try (var is = newInputStream(path)) {
-            content = is.readAllBytes();
-        }
-        return new InMemorySeekableByteChannel(content);
     }
 
     @Override
@@ -290,159 +274,4 @@ final class AzureBlobFileSystemProvider extends FileSystemProvider {
                 : FileTime.from(lastModified.toInstant());
     }
 
-    @Override
-    public Map<String, Object> readAttributes(
-            Path path, String attributes, LinkOption... options) {
-        throw new UnsupportedOperationException(
-                "Attribute-name based reads are not supported;"
-                        + " use readAttributes(Path, Class).");
-    }
-
-    @Override
-    public <V extends FileAttributeView> V getFileAttributeView(
-            Path path, Class<V> type, LinkOption... options) {
-        if (type == BasicFileAttributeView.class) {
-            return type.cast(new BasicFileAttributeView() {
-                @Override
-                public String name() {
-                    return "basic";
-                }
-
-                @Override
-                public BasicFileAttributes readAttributes()
-                        throws IOException {
-                    return AzureBlobFileSystemProvider.this.readAttributes(
-                            path, BasicFileAttributes.class);
-                }
-
-                @Override
-                public void setTimes(
-                        FileTime lastModifiedTime, FileTime lastAccessTime,
-                        FileTime createTime) {
-                    throw new UnsupportedOperationException(
-                            "Azure Blob file systems are read-only.");
-                }
-            });
-        }
-        return null;
-    }
-
-    @Override
-    public void checkAccess(Path path, AccessMode... modes)
-            throws IOException {
-        readAttributes(path, BasicFileAttributes.class);
-        for (var mode : modes) {
-            if (mode == AccessMode.WRITE || mode == AccessMode.EXECUTE) {
-                throw new AccessDeniedException(path.toString());
-            }
-        }
-    }
-
-    @Override
-    public boolean isSameFile(Path path, Path path2) {
-        return path.equals(path2);
-    }
-
-    @Override
-    public boolean isHidden(Path path) {
-        return false;
-    }
-
-    @Override
-    public FileStore getFileStore(Path path) {
-        throw new UnsupportedOperationException(
-                "Azure Blob file systems do not expose file stores.");
-    }
-
-    @Override
-    public void createDirectory(Path dir, FileAttribute<?>... attrs) {
-        throw new UnsupportedOperationException(
-                "Azure Blob file systems are read-only.");
-    }
-
-    @Override
-    public void delete(Path path) {
-        throw new UnsupportedOperationException(
-                "Azure Blob file systems are read-only.");
-    }
-
-    @Override
-    public void copy(Path source, Path target, CopyOption... options) {
-        throw new UnsupportedOperationException(
-                "Azure Blob file systems are read-only.");
-    }
-
-    @Override
-    public void move(Path source, Path target, CopyOption... options) {
-        throw new UnsupportedOperationException(
-                "Azure Blob file systems are read-only.");
-    }
-
-    @Override
-    public void setAttribute(
-            Path path, String attribute, Object value,
-            LinkOption... options) {
-        throw new UnsupportedOperationException(
-                "Azure Blob file systems are read-only.");
-    }
-
-    private static final class InMemorySeekableByteChannel
-            implements SeekableByteChannel {
-
-        private final ByteBuffer buffer;
-        private boolean open = true;
-
-        InMemorySeekableByteChannel(byte[] content) {
-            buffer = ByteBuffer.wrap(content);
-        }
-
-        @Override
-        public int read(ByteBuffer dst) {
-            if (!buffer.hasRemaining()) {
-                return -1;
-            }
-            var count = Math.min(dst.remaining(), buffer.remaining());
-            var slice = buffer.slice();
-            slice.limit(count);
-            dst.put(slice);
-            buffer.position(buffer.position() + count);
-            return count;
-        }
-
-        @Override
-        public int write(ByteBuffer src) {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public long position() {
-            return buffer.position();
-        }
-
-        @Override
-        public SeekableByteChannel position(long newPosition) {
-            buffer.position((int) newPosition);
-            return this;
-        }
-
-        @Override
-        public long size() {
-            return buffer.limit();
-        }
-
-        @Override
-        public SeekableByteChannel truncate(long size) {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public boolean isOpen() {
-            return open;
-        }
-
-        @Override
-        public void close() {
-            open = false;
-        }
-    }
 }

--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/cmis/CmisFileSystemProvider.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/cmis/CmisFileSystemProvider.java
@@ -18,15 +18,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.nio.ByteBuffer;
-import java.nio.channels.NonWritableChannelException;
-import java.nio.channels.SeekableByteChannel;
-import java.nio.file.AccessDeniedException;
-import java.nio.file.AccessMode;
-import java.nio.file.CopyOption;
 import java.nio.file.DirectoryStream;
 import java.nio.file.DirectoryStream.Filter;
-import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystemNotFoundException;
@@ -34,17 +27,13 @@ import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
@@ -55,6 +44,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.message.BasicHeader;
 
 import com.norconex.commons.lang.xml.Xml;
+import com.norconex.crawler.fs.fetch.impl.ReadOnlyFileSystemProvider;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -65,7 +55,7 @@ import lombok.extern.slf4j.Slf4j;
  * object paths within it map to CMIS folder/document paths.
  */
 @Slf4j
-final class CmisFileSystemProvider extends FileSystemProvider {
+final class CmisFileSystemProvider extends ReadOnlyFileSystemProvider {
 
     // no paging: CMIS Atom feeds don't page reliably across servers, and
     // the prior VFS-based implementation never paged either.
@@ -79,6 +69,11 @@ final class CmisFileSystemProvider extends FileSystemProvider {
     @Override
     public String getScheme() {
         return "cmis";
+    }
+
+    @Override
+    protected String fileSystemLabel() {
+        return "CMIS";
     }
 
     /**
@@ -240,17 +235,6 @@ final class CmisFileSystemProvider extends FileSystemProvider {
     }
 
     @Override
-    public SeekableByteChannel newByteChannel(
-            Path path, Set<? extends OpenOption> options,
-            FileAttribute<?>... attrs) throws IOException {
-        byte[] content;
-        try (var is = newInputStream(path)) {
-            content = is.readAllBytes();
-        }
-        return new InMemorySeekableByteChannel(content);
-    }
-
-    @Override
     public DirectoryStream<Path> newDirectoryStream(
             Path dir, Filter<? super Path> filter) throws IOException {
         var cmisPath = (CmisPath) dir;
@@ -322,162 +306,4 @@ final class CmisFileSystemProvider extends FileSystemProvider {
         return (A) attrs;
     }
 
-    @Override
-    public Map<String, Object> readAttributes(
-            Path path, String attributes, LinkOption... options) {
-        throw new UnsupportedOperationException(
-                "Attribute-name based reads are not supported;"
-                        + " use readAttributes(Path, Class).");
-    }
-
-    @Override
-    public <V extends FileAttributeView> V getFileAttributeView(
-            Path path, Class<V> type, LinkOption... options) {
-        if (type == BasicFileAttributeView.class) {
-            return type.cast(new BasicFileAttributeView() {
-                @Override
-                public String name() {
-                    return "basic";
-                }
-
-                @Override
-                public BasicFileAttributes readAttributes()
-                        throws IOException {
-                    return CmisFileSystemProvider.this.readAttributes(
-                            path, BasicFileAttributes.class);
-                }
-
-                @Override
-                public void setTimes(
-                        java.nio.file.attribute.FileTime lastModifiedTime,
-                        java.nio.file.attribute.FileTime lastAccessTime,
-                        java.nio.file.attribute.FileTime createTime) {
-                    throw new UnsupportedOperationException(
-                            "CMIS file systems are read-only.");
-                }
-            });
-        }
-        return null;
-    }
-
-    @Override
-    public void checkAccess(Path path, AccessMode... modes)
-            throws IOException {
-        // Existence check; throws NoSuchFileException if missing.
-        readAttributes(path, BasicFileAttributes.class);
-        for (var mode : modes) {
-            if (mode == AccessMode.WRITE || mode == AccessMode.EXECUTE) {
-                throw new AccessDeniedException(path.toString());
-            }
-        }
-    }
-
-    @Override
-    public boolean isSameFile(Path path, Path path2) {
-        return path.equals(path2);
-    }
-
-    @Override
-    public boolean isHidden(Path path) {
-        return false;
-    }
-
-    @Override
-    public FileStore getFileStore(Path path) {
-        throw new UnsupportedOperationException(
-                "CMIS file systems do not expose file stores.");
-    }
-
-    @Override
-    public void createDirectory(Path dir, FileAttribute<?>... attrs) {
-        throw new UnsupportedOperationException(
-                "CMIS file systems are read-only.");
-    }
-
-    @Override
-    public void delete(Path path) {
-        throw new UnsupportedOperationException(
-                "CMIS file systems are read-only.");
-    }
-
-    @Override
-    public void copy(Path source, Path target, CopyOption... options) {
-        throw new UnsupportedOperationException(
-                "CMIS file systems are read-only.");
-    }
-
-    @Override
-    public void move(Path source, Path target, CopyOption... options) {
-        throw new UnsupportedOperationException(
-                "CMIS file systems are read-only.");
-    }
-
-    @Override
-    public void setAttribute(
-            Path path, String attribute, Object value,
-            LinkOption... options) {
-        throw new UnsupportedOperationException(
-                "CMIS file systems are read-only.");
-    }
-
-    /** A read-only {@link SeekableByteChannel} over an in-memory buffer. */
-    private static final class InMemorySeekableByteChannel
-            implements SeekableByteChannel {
-
-        private final ByteBuffer buffer;
-        private boolean open = true;
-
-        InMemorySeekableByteChannel(byte[] content) {
-            buffer = ByteBuffer.wrap(content);
-        }
-
-        @Override
-        public int read(ByteBuffer dst) {
-            if (!buffer.hasRemaining()) {
-                return -1;
-            }
-            var n = Math.min(dst.remaining(), buffer.remaining());
-            var slice = buffer.slice();
-            slice.limit(n);
-            dst.put(slice);
-            buffer.position(buffer.position() + n);
-            return n;
-        }
-
-        @Override
-        public int write(ByteBuffer src) {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public long position() {
-            return buffer.position();
-        }
-
-        @Override
-        public SeekableByteChannel position(long newPosition) {
-            buffer.position((int) newPosition);
-            return this;
-        }
-
-        @Override
-        public long size() {
-            return buffer.limit();
-        }
-
-        @Override
-        public SeekableByteChannel truncate(long size) {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public boolean isOpen() {
-            return open;
-        }
-
-        @Override
-        public void close() {
-            open = false;
-        }
-    }
 }

--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/hdfs/HdfsFileSystemProvider.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/hdfs/HdfsFileSystemProvider.java
@@ -22,32 +22,20 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
-import java.nio.ByteBuffer;
-import java.nio.channels.NonWritableChannelException;
-import java.nio.channels.SeekableByteChannel;
-import java.nio.file.AccessDeniedException;
-import java.nio.file.AccessMode;
-import java.nio.file.CopyOption;
 import java.nio.file.DirectoryStream;
 import java.nio.file.DirectoryStream.Filter;
-import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.FileAttributeView;
-import java.nio.file.attribute.FileTime;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -64,10 +52,11 @@ import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
 
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
+import com.norconex.crawler.fs.fetch.impl.ReadOnlyFileSystemProvider;
 
 import lombok.extern.slf4j.Slf4j;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * A read-only NIO.2 {@link FileSystemProvider} for HDFS, backed by the
@@ -77,7 +66,7 @@ import lombok.extern.slf4j.Slf4j;
  * used by the native client).
  */
 @Slf4j
-final class HdfsFileSystemProvider extends FileSystemProvider {
+final class HdfsFileSystemProvider extends ReadOnlyFileSystemProvider {
 
     private static final int DEFAULT_PORT = 9870;
     private static final String WEBHDFS_PREFIX = "/webhdfs/v1";
@@ -89,6 +78,11 @@ final class HdfsFileSystemProvider extends FileSystemProvider {
     @Override
     public String getScheme() {
         return "webhdfs";
+    }
+
+    @Override
+    protected String fileSystemLabel() {
+        return "HDFS";
     }
 
     @Override
@@ -234,17 +228,6 @@ final class HdfsFileSystemProvider extends FileSystemProvider {
     }
 
     @Override
-    public SeekableByteChannel newByteChannel(
-            Path path, Set<? extends OpenOption> options,
-            FileAttribute<?>... attrs) throws IOException {
-        byte[] content;
-        try (var is = newInputStream(path)) {
-            content = is.readAllBytes();
-        }
-        return new InMemorySeekableByteChannel(content);
-    }
-
-    @Override
     public DirectoryStream<Path> newDirectoryStream(
             Path dir, Filter<? super Path> filter) throws IOException {
         var hdfsPath = (HdfsPath) dir;
@@ -340,163 +323,4 @@ final class HdfsFileSystemProvider extends FileSystemProvider {
         return new HdfsFileAttributes(directory, length, modTime, accessTime);
     }
 
-    @Override
-    public Map<String, Object> readAttributes(
-            Path path, String attributes, LinkOption... options) {
-        throw new UnsupportedOperationException(
-                "Attribute-name based reads are not supported;"
-                        + " use readAttributes(Path, Class).");
-    }
-
-    @Override
-    public <V extends FileAttributeView> V getFileAttributeView(
-            Path path, Class<V> type, LinkOption... options) {
-        if (type == BasicFileAttributeView.class) {
-            return type.cast(new BasicFileAttributeView() {
-                @Override
-                public String name() {
-                    return "basic";
-                }
-
-                @Override
-                public BasicFileAttributes readAttributes()
-                        throws IOException {
-                    return HdfsFileSystemProvider.this.readAttributes(
-                            path, BasicFileAttributes.class);
-                }
-
-                @Override
-                public void setTimes(
-                        FileTime lastModifiedTime, FileTime lastAccessTime,
-                        FileTime createTime) {
-                    throw new UnsupportedOperationException(
-                            "HDFS file systems are read-only.");
-                }
-            });
-        }
-        return null;
-    }
-
-    // --- Misc -----------------------------------------------------------
-
-    @Override
-    public void checkAccess(Path path, AccessMode... modes)
-            throws IOException {
-        // Existence check; throws NoSuchFileException if missing.
-        readAttributes(path, BasicFileAttributes.class);
-        for (var mode : modes) {
-            if (mode == AccessMode.WRITE || mode == AccessMode.EXECUTE) {
-                throw new AccessDeniedException(path.toString());
-            }
-        }
-    }
-
-    @Override
-    public boolean isSameFile(Path path, Path path2) {
-        return path.equals(path2);
-    }
-
-    @Override
-    public boolean isHidden(Path path) {
-        return false;
-    }
-
-    @Override
-    public FileStore getFileStore(Path path) {
-        throw new UnsupportedOperationException(
-                "HDFS file systems do not expose file stores.");
-    }
-
-    @Override
-    public void createDirectory(Path dir, FileAttribute<?>... attrs) {
-        throw new UnsupportedOperationException(
-                "HDFS file systems are read-only.");
-    }
-
-    @Override
-    public void delete(Path path) {
-        throw new UnsupportedOperationException(
-                "HDFS file systems are read-only.");
-    }
-
-    @Override
-    public void copy(Path source, Path target, CopyOption... options) {
-        throw new UnsupportedOperationException(
-                "HDFS file systems are read-only.");
-    }
-
-    @Override
-    public void move(Path source, Path target, CopyOption... options) {
-        throw new UnsupportedOperationException(
-                "HDFS file systems are read-only.");
-    }
-
-    @Override
-    public void setAttribute(
-            Path path, String attribute, Object value,
-            LinkOption... options) {
-        throw new UnsupportedOperationException(
-                "HDFS file systems are read-only.");
-    }
-
-    /** A read-only {@link SeekableByteChannel} over an in-memory buffer. */
-    private static final class InMemorySeekableByteChannel
-            implements SeekableByteChannel {
-
-        private final ByteBuffer buffer;
-        private boolean open = true;
-
-        InMemorySeekableByteChannel(byte[] content) {
-            buffer = ByteBuffer.wrap(content);
-        }
-
-        @Override
-        public int read(ByteBuffer dst) {
-            if (!buffer.hasRemaining()) {
-                return -1;
-            }
-            var n = Math.min(dst.remaining(), buffer.remaining());
-            var slice = buffer.slice();
-            slice.limit(n);
-            dst.put(slice);
-            buffer.position(buffer.position() + n);
-            return n;
-        }
-
-        @Override
-        public int write(ByteBuffer src) {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public long position() {
-            return buffer.position();
-        }
-
-        @Override
-        public SeekableByteChannel position(long newPosition) {
-            buffer.position((int) newPosition);
-            return this;
-        }
-
-        @Override
-        public long size() {
-            return buffer.limit();
-        }
-
-        @Override
-        public SeekableByteChannel truncate(long size) {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public boolean isOpen() {
-            return open;
-        }
-
-        @Override
-        public void close() {
-            open = false;
-        }
-    }
 }

--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/s3/S3FileSystemProvider.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/s3/S3FileSystemProvider.java
@@ -17,25 +17,15 @@ package com.norconex.crawler.fs.fetch.impl.s3;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.nio.ByteBuffer;
-import java.nio.channels.NonWritableChannelException;
-import java.nio.channels.SeekableByteChannel;
-import java.nio.file.AccessDeniedException;
-import java.nio.file.AccessMode;
-import java.nio.file.CopyOption;
 import java.nio.file.DirectoryStream;
 import java.nio.file.DirectoryStream.Filter;
-import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.nio.file.spi.FileSystemProvider;
 import java.time.Instant;
@@ -43,19 +33,19 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.norconex.crawler.fs.fetch.impl.ReadOnlyFileSystemProvider;
+
+import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.S3Exception;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * A read-only NIO.2 {@link FileSystemProvider} for S3, backed directly by
@@ -66,7 +56,7 @@ import lombok.extern.slf4j.Slf4j;
  * {@code /} delimiter.
  */
 @Slf4j
-final class S3FileSystemProvider extends FileSystemProvider {
+final class S3FileSystemProvider extends ReadOnlyFileSystemProvider {
 
     private static final int HTTP_NOT_FOUND = 404;
 
@@ -76,6 +66,11 @@ final class S3FileSystemProvider extends FileSystemProvider {
     @Override
     public String getScheme() {
         return "s3";
+    }
+
+    @Override
+    protected String fileSystemLabel() {
+        return "S3";
     }
 
     @Override
@@ -143,17 +138,6 @@ final class S3FileSystemProvider extends FileSystemProvider {
             throw new IOException(
                     "Could not read S3 object: " + s3Path.path(), e);
         }
-    }
-
-    @Override
-    public SeekableByteChannel newByteChannel(
-            Path path, Set<? extends OpenOption> options,
-            FileAttribute<?>... attrs) throws IOException {
-        byte[] content;
-        try (var is = newInputStream(path)) {
-            content = is.readAllBytes();
-        }
-        return new InMemorySeekableByteChannel(content);
     }
 
     @Override
@@ -298,163 +282,4 @@ final class S3FileSystemProvider extends FileSystemProvider {
         return instant == null ? null : FileTime.from(instant);
     }
 
-    @Override
-    public Map<String, Object> readAttributes(
-            Path path, String attributes, LinkOption... options) {
-        throw new UnsupportedOperationException(
-                "Attribute-name based reads are not supported;"
-                        + " use readAttributes(Path, Class).");
-    }
-
-    @Override
-    public <V extends FileAttributeView> V getFileAttributeView(
-            Path path, Class<V> type, LinkOption... options) {
-        if (type == BasicFileAttributeView.class) {
-            return type.cast(new BasicFileAttributeView() {
-                @Override
-                public String name() {
-                    return "basic";
-                }
-
-                @Override
-                public BasicFileAttributes readAttributes()
-                        throws IOException {
-                    return S3FileSystemProvider.this.readAttributes(
-                            path, BasicFileAttributes.class);
-                }
-
-                @Override
-                public void setTimes(
-                        FileTime lastModifiedTime, FileTime lastAccessTime,
-                        FileTime createTime) {
-                    throw new UnsupportedOperationException(
-                            "S3 file systems are read-only.");
-                }
-            });
-        }
-        return null;
-    }
-
-    // --- Misc -----------------------------------------------------------
-
-    @Override
-    public void checkAccess(Path path, AccessMode... modes)
-            throws IOException {
-        // Existence check; throws NoSuchFileException if missing.
-        readAttributes(path, BasicFileAttributes.class);
-        for (var mode : modes) {
-            if (mode == AccessMode.WRITE || mode == AccessMode.EXECUTE) {
-                throw new AccessDeniedException(path.toString());
-            }
-        }
-    }
-
-    @Override
-    public boolean isSameFile(Path path, Path path2) {
-        return path.equals(path2);
-    }
-
-    @Override
-    public boolean isHidden(Path path) {
-        return false;
-    }
-
-    @Override
-    public FileStore getFileStore(Path path) {
-        throw new UnsupportedOperationException(
-                "S3 file systems do not expose file stores.");
-    }
-
-    @Override
-    public void createDirectory(Path dir, FileAttribute<?>... attrs) {
-        throw new UnsupportedOperationException(
-                "S3 file systems are read-only.");
-    }
-
-    @Override
-    public void delete(Path path) {
-        throw new UnsupportedOperationException(
-                "S3 file systems are read-only.");
-    }
-
-    @Override
-    public void copy(Path source, Path target, CopyOption... options) {
-        throw new UnsupportedOperationException(
-                "S3 file systems are read-only.");
-    }
-
-    @Override
-    public void move(Path source, Path target, CopyOption... options) {
-        throw new UnsupportedOperationException(
-                "S3 file systems are read-only.");
-    }
-
-    @Override
-    public void setAttribute(
-            Path path, String attribute, Object value,
-            LinkOption... options) {
-        throw new UnsupportedOperationException(
-                "S3 file systems are read-only.");
-    }
-
-    /** A read-only {@link SeekableByteChannel} over an in-memory buffer. */
-    private static final class InMemorySeekableByteChannel
-            implements SeekableByteChannel {
-
-        private final ByteBuffer buffer;
-        private boolean open = true;
-
-        InMemorySeekableByteChannel(byte[] content) {
-            buffer = ByteBuffer.wrap(content);
-        }
-
-        @Override
-        public int read(ByteBuffer dst) {
-            if (!buffer.hasRemaining()) {
-                return -1;
-            }
-            var n = Math.min(dst.remaining(), buffer.remaining());
-            var slice = buffer.slice();
-            slice.limit(n);
-            dst.put(slice);
-            buffer.position(buffer.position() + n);
-            return n;
-        }
-
-        @Override
-        public int write(ByteBuffer src) {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public long position() {
-            return buffer.position();
-        }
-
-        @Override
-        public SeekableByteChannel position(long newPosition) {
-            buffer.position((int) newPosition);
-            return this;
-        }
-
-        @Override
-        public long size() {
-            return buffer.limit();
-        }
-
-        @Override
-        public SeekableByteChannel truncate(long size) {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public boolean isOpen() {
-            return open;
-        }
-
-        @Override
-        public void close() {
-            open = false;
-        }
-    }
 }

--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/smb/SmbFileSystemProvider.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/smb/SmbFileSystemProvider.java
@@ -19,41 +19,30 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
-import java.nio.channels.NonWritableChannelException;
-import java.nio.channels.SeekableByteChannel;
-import java.nio.file.AccessDeniedException;
-import java.nio.file.AccessMode;
-import java.nio.file.CopyOption;
 import java.nio.file.DirectoryStream;
 import java.nio.file.DirectoryStream.Filter;
-import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.FileAttributeView;
-import java.nio.file.attribute.FileTime;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 
+import com.norconex.crawler.fs.fetch.impl.ReadOnlyFileSystemProvider;
+
 import jcifs.ACE;
 import jcifs.CIFSContext;
 import jcifs.smb.SmbFile;
-
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -63,7 +52,7 @@ import lombok.extern.slf4j.Slf4j;
  * paths within it map to SMB share + path.
  */
 @Slf4j
-final class SmbFileSystemProvider extends FileSystemProvider {
+final class SmbFileSystemProvider extends ReadOnlyFileSystemProvider {
 
     private static final int DEFAULT_PORT = 445;
 
@@ -73,6 +62,11 @@ final class SmbFileSystemProvider extends FileSystemProvider {
     @Override
     public String getScheme() {
         return "smb";
+    }
+
+    @Override
+    protected String fileSystemLabel() {
+        return "SMB";
     }
 
     @Override
@@ -168,17 +162,6 @@ final class SmbFileSystemProvider extends FileSystemProvider {
     }
 
     @Override
-    public SeekableByteChannel newByteChannel(
-            Path path, Set<? extends OpenOption> options,
-            FileAttribute<?>... attrs) throws IOException {
-        byte[] content;
-        try (var is = newInputStream(path)) {
-            content = is.readAllBytes();
-        }
-        return new InMemorySeekableByteChannel(content);
-    }
-
-    @Override
     public DirectoryStream<Path> newDirectoryStream(
             Path dir, Filter<? super Path> filter) throws IOException {
         var smbPath = (SmbPath) dir;
@@ -256,43 +239,6 @@ final class SmbFileSystemProvider extends FileSystemProvider {
         }
     }
 
-    @Override
-    public Map<String, Object> readAttributes(
-            Path path, String attributes, LinkOption... options) {
-        throw new UnsupportedOperationException(
-                "Attribute-name based reads are not supported;"
-                        + " use readAttributes(Path, Class).");
-    }
-
-    @Override
-    public <V extends FileAttributeView> V getFileAttributeView(
-            Path path, Class<V> type, LinkOption... options) {
-        if (type == BasicFileAttributeView.class) {
-            return type.cast(new BasicFileAttributeView() {
-                @Override
-                public String name() {
-                    return "basic";
-                }
-
-                @Override
-                public BasicFileAttributes readAttributes()
-                        throws IOException {
-                    return SmbFileSystemProvider.this.readAttributes(
-                            path, BasicFileAttributes.class);
-                }
-
-                @Override
-                public void setTimes(
-                        FileTime lastModifiedTime, FileTime lastAccessTime,
-                        FileTime createTime) {
-                    throw new UnsupportedOperationException(
-                            "SMB file systems are read-only.");
-                }
-            });
-        }
-        return null;
-    }
-
     // --- ACL -----------------------------------------------------------
 
     /**
@@ -315,126 +261,4 @@ final class SmbFileSystemProvider extends FileSystemProvider {
         }
     }
 
-    // --- Misc ------------------------------------------------------------
-
-    @Override
-    public void checkAccess(Path path, AccessMode... modes)
-            throws IOException {
-        // Existence check; throws NoSuchFileException if missing.
-        readAttributes(path, BasicFileAttributes.class);
-        for (var mode : modes) {
-            if (mode == AccessMode.WRITE || mode == AccessMode.EXECUTE) {
-                throw new AccessDeniedException(path.toString());
-            }
-        }
-    }
-
-    @Override
-    public boolean isSameFile(Path path, Path path2) {
-        return path.equals(path2);
-    }
-
-    @Override
-    public boolean isHidden(Path path) {
-        return false;
-    }
-
-    @Override
-    public FileStore getFileStore(Path path) {
-        throw new UnsupportedOperationException(
-                "SMB file systems do not expose file stores.");
-    }
-
-    @Override
-    public void createDirectory(Path dir, FileAttribute<?>... attrs) {
-        throw new UnsupportedOperationException(
-                "SMB file systems are read-only.");
-    }
-
-    @Override
-    public void delete(Path path) {
-        throw new UnsupportedOperationException(
-                "SMB file systems are read-only.");
-    }
-
-    @Override
-    public void copy(Path source, Path target, CopyOption... options) {
-        throw new UnsupportedOperationException(
-                "SMB file systems are read-only.");
-    }
-
-    @Override
-    public void move(Path source, Path target, CopyOption... options) {
-        throw new UnsupportedOperationException(
-                "SMB file systems are read-only.");
-    }
-
-    @Override
-    public void setAttribute(
-            Path path, String attribute, Object value,
-            LinkOption... options) {
-        throw new UnsupportedOperationException(
-                "SMB file systems are read-only.");
-    }
-
-    /** A read-only {@link SeekableByteChannel} over an in-memory buffer. */
-    private static final class InMemorySeekableByteChannel
-            implements SeekableByteChannel {
-
-        private final ByteBuffer buffer;
-        private boolean open = true;
-
-        InMemorySeekableByteChannel(byte[] content) {
-            buffer = ByteBuffer.wrap(content);
-        }
-
-        @Override
-        public int read(ByteBuffer dst) {
-            if (!buffer.hasRemaining()) {
-                return -1;
-            }
-            var n = Math.min(dst.remaining(), buffer.remaining());
-            var slice = buffer.slice();
-            slice.limit(n);
-            dst.put(slice);
-            buffer.position(buffer.position() + n);
-            return n;
-        }
-
-        @Override
-        public int write(ByteBuffer src) {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public long position() {
-            return buffer.position();
-        }
-
-        @Override
-        public SeekableByteChannel position(long newPosition) {
-            buffer.position((int) newPosition);
-            return this;
-        }
-
-        @Override
-        public long size() {
-            return buffer.limit();
-        }
-
-        @Override
-        public SeekableByteChannel truncate(long size) {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public boolean isOpen() {
-            return open;
-        }
-
-        @Override
-        public void close() {
-            open = false;
-        }
-    }
 }

--- a/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/webdav/WebDavFileSystemProvider.java
+++ b/crawler/fs/src/main/java/com/norconex/crawler/fs/fetch/impl/webdav/WebDavFileSystemProvider.java
@@ -20,16 +20,9 @@ import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
-import java.nio.channels.NonWritableChannelException;
-import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.AccessDeniedException;
-import java.nio.file.AccessMode;
-import java.nio.file.CopyOption;
 import java.nio.file.DirectoryStream;
 import java.nio.file.DirectoryStream.Filter;
-import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystemNotFoundException;
@@ -37,10 +30,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileAttribute;
-import java.nio.file.attribute.FileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.nio.file.spi.FileSystemProvider;
 import java.time.ZonedDateTime;
@@ -68,6 +58,7 @@ import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 
 import com.norconex.commons.lang.xml.Xml;
+import com.norconex.crawler.fs.fetch.impl.ReadOnlyFileSystemProvider;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -87,7 +78,7 @@ import lombok.extern.slf4j.Slf4j;
  * </p>
  */
 @Slf4j
-final class WebDavFileSystemProvider extends FileSystemProvider {
+final class WebDavFileSystemProvider extends ReadOnlyFileSystemProvider {
 
     // Env keys populated by WebDavFetcher.
     static final String ENV_CLIENT_SUPPLIER = "clientSupplier";
@@ -101,6 +92,11 @@ final class WebDavFileSystemProvider extends FileSystemProvider {
     @Override
     public String getScheme() {
         return "webdav";
+    }
+
+    @Override
+    protected String fileSystemLabel() {
+        return "WebDAV";
     }
 
     @Override
@@ -231,17 +227,6 @@ final class WebDavFileSystemProvider extends FileSystemProvider {
     }
 
     @Override
-    public SeekableByteChannel newByteChannel(
-            Path path, Set<? extends OpenOption> options,
-            FileAttribute<?>... attrs) throws IOException {
-        byte[] content;
-        try (var is = newInputStream(path)) {
-            content = is.readAllBytes();
-        }
-        return new InMemorySeekableByteChannel(content);
-    }
-
-    @Override
     public DirectoryStream<Path> newDirectoryStream(
             Path dir, Filter<? super Path> filter) throws IOException {
         var wdPath = (WebDavPath) dir;
@@ -308,103 +293,6 @@ final class WebDavFileSystemProvider extends FileSystemProvider {
         }
         fs.attrsCache().put(wdPath.path(), attrs);
         return (A) attrs;
-    }
-
-    @Override
-    public Map<String, Object> readAttributes(
-            Path path, String attributes, LinkOption... options) {
-        throw new UnsupportedOperationException(
-                "Attribute-name based reads are not supported;"
-                        + " use readAttributes(Path, Class).");
-    }
-
-    @Override
-    public <V extends FileAttributeView> V getFileAttributeView(
-            Path path, Class<V> type, LinkOption... options) {
-        if (type == BasicFileAttributeView.class) {
-            return type.cast(new BasicFileAttributeView() {
-                @Override
-                public String name() {
-                    return "basic";
-                }
-
-                @Override
-                public BasicFileAttributes readAttributes()
-                        throws IOException {
-                    return WebDavFileSystemProvider.this.readAttributes(
-                            path, BasicFileAttributes.class);
-                }
-
-                @Override
-                public void setTimes(
-                        FileTime lastModifiedTime, FileTime lastAccessTime,
-                        FileTime createTime) {
-                    throw new UnsupportedOperationException(
-                            "WebDAV file systems are read-only.");
-                }
-            });
-        }
-        return null;
-    }
-
-    @Override
-    public void checkAccess(Path path, AccessMode... modes)
-            throws IOException {
-        // Existence check; throws NoSuchFileException if missing.
-        readAttributes(path, BasicFileAttributes.class);
-        for (var mode : modes) {
-            if (mode == AccessMode.WRITE || mode == AccessMode.EXECUTE) {
-                throw new AccessDeniedException(path.toString());
-            }
-        }
-    }
-
-    @Override
-    public boolean isSameFile(Path path, Path path2) {
-        return path.equals(path2);
-    }
-
-    @Override
-    public boolean isHidden(Path path) {
-        return false;
-    }
-
-    @Override
-    public FileStore getFileStore(Path path) {
-        throw new UnsupportedOperationException(
-                "WebDAV file systems do not expose file stores.");
-    }
-
-    @Override
-    public void createDirectory(Path dir, FileAttribute<?>... attrs) {
-        throw new UnsupportedOperationException(
-                "WebDAV file systems are read-only.");
-    }
-
-    @Override
-    public void delete(Path path) {
-        throw new UnsupportedOperationException(
-                "WebDAV file systems are read-only.");
-    }
-
-    @Override
-    public void copy(Path source, Path target, CopyOption... options) {
-        throw new UnsupportedOperationException(
-                "WebDAV file systems are read-only.");
-    }
-
-    @Override
-    public void move(Path source, Path target, CopyOption... options) {
-        throw new UnsupportedOperationException(
-                "WebDAV file systems are read-only.");
-    }
-
-    @Override
-    public void setAttribute(
-            Path path, String attribute, Object value,
-            LinkOption... options) {
-        throw new UnsupportedOperationException(
-                "WebDAV file systems are read-only.");
     }
 
     // --- WebDAV protocol -------------------------------------------------
@@ -583,64 +471,4 @@ final class WebDavFileSystemProvider extends FileSystemProvider {
         return path;
     }
 
-    /** A read-only {@link SeekableByteChannel} over an in-memory buffer. */
-    private static final class InMemorySeekableByteChannel
-            implements SeekableByteChannel {
-
-        private final ByteBuffer buffer;
-        private boolean open = true;
-
-        InMemorySeekableByteChannel(byte[] content) {
-            buffer = ByteBuffer.wrap(content);
-        }
-
-        @Override
-        public int read(ByteBuffer dst) {
-            if (!buffer.hasRemaining()) {
-                return -1;
-            }
-            var n = Math.min(dst.remaining(), buffer.remaining());
-            var slice = buffer.slice();
-            slice.limit(n);
-            dst.put(slice);
-            buffer.position(buffer.position() + n);
-            return n;
-        }
-
-        @Override
-        public int write(ByteBuffer src) {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public long position() {
-            return buffer.position();
-        }
-
-        @Override
-        public SeekableByteChannel position(long newPosition) {
-            buffer.position((int) newPosition);
-            return this;
-        }
-
-        @Override
-        public long size() {
-            return buffer.limit();
-        }
-
-        @Override
-        public SeekableByteChannel truncate(long size) {
-            throw new NonWritableChannelException();
-        }
-
-        @Override
-        public boolean isOpen() {
-            return open;
-        }
-
-        @Override
-        public void close() {
-            open = false;
-        }
-    }
 }


### PR DESCRIPTION
- Created a new abstract class ReadOnlyFileSystemProvider to encapsulate common read-only behavior for various file system providers.
- Updated CmisFileSystemProvider, HdfsFileSystemProvider, S3FileSystemProvider, SmbFileSystemProvider, and WebDavFileSystemProvider to extend ReadOnlyFileSystemProvider.
- Removed redundant methods and exceptions related to read-only operations from individual providers.
- Simplified the implementation of read attributes and byte channel creation in the new base class.

Signed-off-by: Pascal Essiembre <pascal.essiembre@norconex.com>

## Description

<!-- Describe the changes in this pull request. -->

## Motivation & Context

<!-- Why is this change needed? What problem does it solve? -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Internal/maintenance (CI, formatting, refactoring with no user impact)

## Contributor Agreement

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the DCO
- [ ] All commits in this PR are signed off (`-s`) and GPG-signed (`-S`)

## Testing

<!-- How has this been tested? -->

## Release Notes

**If this PR will be included in an upcoming release, describe the user-facing change here (1-2 lines):**

<!-- Example:
"Fixed URL encoding in query parameters (fixes #123)"
or
"Added support for parallel processing with new maxThreads configuration"
-->

---

**Note:** When a release is prepared, the changelog file will be built from merged PRs and the release notes provided above.
